### PR TITLE
Fixes #4: sdk should only depend on cloudevents-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>io.cloudevents</groupId>
-			<artifactId>cloudevents-http-basic</artifactId>
-			<version>${cloudevents.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.cloudevents</groupId>
-			<artifactId>cloudevents-json-jackson</artifactId>
+			<artifactId>cloudevents-core</artifactId>
 			<version>${cloudevents.version}</version>
 		</dependency>
 		


### PR DESCRIPTION
The SDK should require neither `cloudevents-http-basic` nor `cloudevents-json-jackson`. At this point, the dependency on `cloudevents-core` is sufficent.