### PR TITLE
Use CDEvents bot for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
 env:
   JAVA_VERSION: '11'
   JAVA_DISTRO: 'zulu'
-  USER_EMAIL: '41898282+github-actions[bot]@users.noreply.github.com'
-  USER_NAME: 'GitHub Action'
+  USER_EMAIL: 'cdevents@cd.foundation'
+  USER_NAME: 'CDEvents Bot'
 
 jobs:
   release:
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_BOT_TOKEN }}
 
       - name: Setup Java
         uses: actions/setup-java@v3


### PR DESCRIPTION
In the release workflow, use the PAT of `cdevents-bot` to bypass branch protection