### PR TITLE
Fixes #16 by adding ModiTect to generate a full Java module descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,36 @@
 					</archive>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.moditect</groupId>
+				<artifactId>moditect-maven-plugin</artifactId>
+				<version>1.0.0.RC3</version>
+				<executions>
+					<execution>
+						<id>add-module-infos</id>
+						<phase>package</phase>
+						<goals>
+							<goal>add-module-info</goal>
+						</goals>
+						<configuration>
+							<jvmVersion>9</jvmVersion>
+							<overwriteExistingFiles>true</overwriteExistingFiles>
+							<module>
+								<moduleInfo>
+									<name>dev.cdevents</name>
+									<!-- export everything -->
+									<exports>*;</exports>
+									<!-- declare services consumed by the artifact -->
+									<addServiceUses>true</addServiceUses>
+								</moduleInfo>
+							</module>
+							<jdepsExtraArgs>
+								<arg>--multi-release=9</arg>
+							</jdepsExtraArgs>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Resolved Java module looks like this:

```
$ jarviz module descriptor --file target/cdevents-sdk-java-v0.1.0-draft6.jar 
subject: cdevents-sdk-java-v0.1.0-draft6.jar
name: dev.cdevents
open: false
automatic: false
exports:
  dev.cdevents
  dev.cdevents.constants
  dev.cdevents.models
requires:
  com.fasterxml.jackson.core
  com.fasterxml.jackson.databind
  io.cloudevents.api
  io.cloudevents.core
  java.base mandated
  org.slf4j
```

Bytecode remains Java 8 compatible

```
$ jarviz bytecode show --file target/cdevents-sdk-java-v0.1.0-draft6.jar --details
subject: cdevents-sdk-java-v0.1.0-draft6.jar
Unversioned classes. Bytecode version: 52 (Java 8) total: 7
dev.cdevents.CDEventTypes
dev.cdevents.constants.CDEventConstants.Outcome
dev.cdevents.constants.CDEventConstants
dev.cdevents.constants.CDEventConstants.CDEventTypes
dev.cdevents.models.Environment
dev.cdevents.models.Repository
dev.cdevents.models.PipelineRun
Versioned classes 9. Bytecode version: 53 (Java 9) total: 1
module-info
```

JAR file is correctly identified as multi-release

```
$ jarviz manifest show --file target/cdevents-sdk-java-v0.1.0-draft6.jar
subject: cdevents-sdk-java-v0.1.0-draft6.jar
Manifest-Version: 1.0
Created-By: Maven Jar Plugin 3.2.0
Build-Jdk-Spec: 11
Implementation-Title: cdevents-sdk-java
Implementation-Version: v0.1.0-draft6
Implementation-Vendor: Continuous Delivery Foundation
Build-Jdk: 11.0.17 (Azul Systems, Inc. 11.0.17+8-LTS)
Build-OS: Mac OS X x86_64 11.6.5
Multi-Release: true
```

`module-info.class` is placed in versioned space

```
$ unzip -l target/cdevents-sdk-java-v0.1.0-draft6.jar 
Archive:  target/cdevents-sdk-java-v0.1.0-draft6.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
      326  04-27-2023 10:20   META-INF/MANIFEST.MF
        0  04-27-2023 10:20   META-INF/
        0  04-27-2023 10:20   dev/
        0  04-27-2023 10:20   dev/cdevents/
        0  04-27-2023 10:20   dev/cdevents/constants/
        0  04-27-2023 10:20   dev/cdevents/models/
        0  04-27-2023 10:20   META-INF/maven/
        0  04-27-2023 10:20   META-INF/maven/dev.cdevents.sdk-java/
        0  04-27-2023 10:20   META-INF/maven/dev.cdevents.sdk-java/cdevents-sdk-java/
    14814  04-27-2023 10:20   dev/cdevents/CDEventTypes.class
     1621  04-27-2023 10:20   dev/cdevents/constants/CDEventConstants$Outcome.class
      568  04-27-2023 10:20   dev/cdevents/constants/CDEventConstants.class
     5370  04-27-2023 10:20   dev/cdevents/constants/CDEventConstants$CDEventTypes.class
     1302  04-27-2023 10:20   dev/cdevents/models/Environment.class
     1524  04-27-2023 10:20   dev/cdevents/models/Repository.class
     1854  04-27-2023 10:20   dev/cdevents/models/PipelineRun.class
    10829  04-27-2023 10:20   META-INF/maven/dev.cdevents.sdk-java/cdevents-sdk-java/pom.xml
       81  04-27-2023 10:20   META-INF/maven/dev.cdevents.sdk-java/cdevents-sdk-java/pom.properties
        0  04-27-2023 10:20   META-INF/versions/
        0  04-27-2023 10:20   META-INF/versions/9/
      378  04-27-2023 10:20   META-INF/versions/9/module-info.class
---------                     -------
    38667                     21 files
```