### PR TITLE
Fix #22 Configure releases to Maven Central and GitHub with JReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,35 +32,46 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
-          server-id: central
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_CENTRAL_TOKEN
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
-
-      - name: Cache Maven
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: Set Version
         run: |
           VERSION=${{ github.event.inputs.version }}
           echo "Updating POMs to version $VERSION"
-          ./mvnw -B versions:set versions:commit -DnewVersion=$VERSION
+          ./mvnw -ntp -B versions:set versions:commit -DnewVersion=$VERSION
           git config --global user.email "${{ env.USER_EMAIL }}"
           git config --global user.name "${{ env.USER_NAME }}"
           git commit -a -s -m "Releasing version $VERSION"
           git push
 
-      - name: Release
-        env:
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Stage deploy
         run: |
-          ./mvnw --no-transfer-progress -B --file pom.xml \
-            -Drepository.url=https://github.com/${{ github.repository }} \
-            -Dmaven.site.skip=true -Drelease=true deploy
+          ./mvnw -ntp -B --file pom.xml -Ppublication
+
+      - name: Release
+        run: |
+          ./mvnw -ntp -B --file pom.xml -Prelease
+        env:
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          JRELEASER_NEXUS2_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          JRELEASER_NEXUS2_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+
+      - name: JReleaser output
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: jreleaser-release
+          path: |
+            target/jreleaser/trace.log
+            target/jreleaser/output.properties
+
+      - name: Bump to snapshot
+        run: |
+          ./mvnw -ntp -B versions:set versions:commit -DnextSnapshot=true
+          git config --global user.email "${{ env.USER_EMAIL }}"
+          git config --global user.name "${{ env.USER_NAME }}"
+          git commit -a -s -m "Bump version to next snapshot"
+          git push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,7 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
-
-      - name: Cache Maven
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: Build
-        run: ./mvnw --no-transfer-progress -B --file pom.xml verify
+        run: ./mvnw -ntp -B --file pom.xml verify

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,10 @@
 		<version.compiler.plugin>3.11.0</version.compiler.plugin>
 		<version.deploy.plugin>3.1.1</version.deploy.plugin>
 		<version.git.plugin>5.0.0</version.git.plugin>
-		<version.gpg.plugin>1.6</version.gpg.plugin>
 		<version.install.plugin>3.1.1</version.install.plugin>
-		<version.javadoc.plugin>3..0</version.javadoc.plugin>
+		<version.javadoc.plugin>3.5.0</version.javadoc.plugin>
 		<version.jar.plugin>3.3.0</version.jar.plugin>
-		<version.nexus.plugin>1.6.8</version.nexus.plugin>
+		<version.jreleaser.plugin>1.6.0</version.jreleaser.plugin>
 		<version.resources.plugin>3.3.1</version.resources.plugin>
 		<version.source.plugin>3.2.1</version.source.plugin>
 	</properties>
@@ -144,6 +143,7 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
 	<build>
 		<pluginManagement>
 			<plugins>
@@ -161,11 +161,6 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-deploy-plugin</artifactId>
 					<version>${version.deploy.plugin}</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-gpg-plugin</artifactId>
-					<version>${version.gpg.plugin}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -191,11 +186,6 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
 					<version>${version.source.plugin}</version>
-				</plugin>
-				<plugin>
-					<groupId>org.sonatype.plugins</groupId>
-					<artifactId>nexus-staging-maven-plugin</artifactId>
-					<version>${version.nexus.plugin}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -274,21 +264,6 @@
         </plugins>
     </build>
 
-	<distributionManagement>
-		<repository>
-			<id>ossrh</id>
-			<url>${nexus.url}/service/local/staging/deploy/maven2/</url>
-		</repository>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>${nexus.url}/content/repositories/snapshots</url>
-		</snapshotRepository>
-		<site>
-			<id>kordamp</id>
-			<url>scm:git:ssh://git@github.com/${project.github.repository}.git</url>
-		</site>
-	</distributionManagement>
-
 	<profiles>
 		<profile>
 			<id>publication</id>
@@ -297,7 +272,11 @@
 					<name>release</name>
 				</property>
 			</activation>
+			<properties>
+				<altDeploymentRepository>local::file:./target/staging-deploy</altDeploymentRepository>
+			</properties>
 			<build>
+				<defaultGoal>deploy</defaultGoal>
 				<plugins>
 					<plugin>
 						<groupId>com.coderplus.maven.plugins</groupId>
@@ -352,54 +331,61 @@
 		</profile>
 
 		<profile>
-			<id>gpg</id>
+			<id>release</id>
 			<activation>
 				<property>
 					<name>release</name>
 				</property>
 			</activation>
 			<build>
+				<defaultGoal>jreleaser:full-release</defaultGoal>
 				<plugins>
 					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<executions>
-							<execution>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-								<phase>verify</phase>
-								<configuration>
-									<gpgArguments>
-										<arg>--pinentry-mode</arg>
-										<arg>loopback</arg>
-									</gpgArguments>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-
-		<profile>
-			<id>remote-deploy</id>
-			<activation>
-				<property>
-					<name>release</name>
-				</property>
-			</activation>
-			<build>
-				<defaultGoal>deploy</defaultGoal>
-				<plugins>
-					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<extensions>true</extensions>
+						<groupId>org.jreleaser</groupId>
+						<artifactId>jreleaser-maven-plugin</artifactId>
 						<configuration>
-							<serverId>central</serverId>
-							<nexusUrl>${nexus.url}</nexusUrl>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose>
+							<jreleaser>
+								<release>
+									<github>
+										<issues>
+											<enabled>true</enabled>
+										</issues>
+										<changelog>
+											<skipMergeCommits>true</skipMergeCommits>
+											<formatted>ALWAYS</formatted>
+											<format>- {{commitShortHash}} {{commitTitle}}</format>
+											<contributors>
+												<format>- {{contributorName}}{{#contributorUsernameAsLink}} ({{.}}){{/contributorUsernameAsLink}}</format>
+											</contributors>
+											<hide>
+												<contributors>
+													<contributor>bot</contributor>
+													<contributor>Bot</contributor>
+													<contributor>GitHub</contributor>
+												</contributors>
+											</hide>
+										</changelog>
+									</github>
+								</release>
+								<signing>
+									<active>ALWAYS</active>
+									<armored>true</armored>
+								</signing>
+								<deploy>
+									<maven>
+										<nexus2>
+											<maven-central>
+												<active>ALWAYS</active>
+												<url>https://s01.oss.sonatype.org/service/local</url>
+												<snapshotUrl>https://s01.oss.sonatype.org/content/repositories/snapshots/</snapshotUrl>
+												<closeRepository>true</closeRepository>
+												<releaseRepository>true</releaseRepository>
+												<stagingRepositories>target/staging-deploy</stagingRepositories>
+											</maven-central>
+										</nexus2>
+									</maven>
+								</deploy>
+							</jreleaser>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
@afrittoli this setup requires adding one extra secret: `GPG_PUBLIC_KEY`. It's required for verifying local signatures.
If this were to be a problem and the project rather not put the public key as a secret I think it's possible to skip local signature verification, in which case an update to the settings would be required.

An additional benefit is that the JReleaser plugin will also let the project announce releases if the desired [announcers](https://jreleaser.org/guide/latest/reference/announce/index.html) were to be configured.