### PR TITLE
Update moditect settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
 			<plugin>
 				<groupId>org.moditect</groupId>
 				<artifactId>moditect-maven-plugin</artifactId>
-				<version>1.0.0.RC3</version>
+				<version>1.0.0.Final</version>
 				<executions>
 					<execution>
 						<id>add-module-infos</id>
@@ -252,8 +252,8 @@
 							<goal>add-module-info</goal>
 						</goals>
 						<configuration>
-							<jvmVersion>9</jvmVersion>
 							<overwriteExistingFiles>true</overwriteExistingFiles>
+							<failOnWarning>false</failOnWarning>
 							<module>
 								<moduleInfo>
 									<name>dev.cdevents</name>


### PR DESCRIPTION
Update required to avoid the following error when building without invoking `clean` between compilation/packaging invocations

```
[ERROR] Failed to execute goal org.moditect:moditect-maven-plugin:1.0.0.RC3:add-module-info (add-module-infos) on project cdevents-sdk-java: File cdevents-sdk-java-0.1.2-SNAPSHOT.jar is already modular -> [Help 1]
```