### PR TITLE
Update links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,5 @@ If you would like to contribute, see our [development](DEVELOPMENT.md) guide.
 ## References
 
 - [CDEvents](https://cdevents.dev)
-- [CDFoundation SIG Events Vocabulary Draft](https://github.com/cdfoundation/sig-events/tree/main/vocabulary-draft)
+- [CDEvents Primer](https://cdevents.dev/docs/primer/)
+- [CDFoundation Specification](https://cdevents.dev/docs/)


### PR DESCRIPTION
The specification in the sig-events repo is deprecated and should not be linked to anymore.
Add links to the current primer and spec instead.