### PR TITLE
Java SDK tests against examples from the spec repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,12 @@ jobs:
 
       - name: Build
         run: ./mvnw -ntp -B --file pom.xml verify
+
+      - name: Generate Surefire test reports
+        run: ./mvnw surefire-report:report
+
+      - name: Access Surefire test report
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: ./sdk/target/site/

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -72,7 +72,7 @@
                 <version>1.2.1</version>
                 <configuration>
                     <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
-                    <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                    <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                     <includeToString>false</includeToString>
                     <addCompileSourceRoot>false</addCompileSourceRoot>
                 </configuration>
@@ -89,7 +89,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.artifact.packaged</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -105,7 +105,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.artifact.published</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -121,7 +121,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.artifact.signed</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -137,7 +137,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.branch.created</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -153,7 +153,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.branch.deleted</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -169,7 +169,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.build.finished</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -185,7 +185,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.build.queued</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -201,7 +201,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.build.started</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -217,7 +217,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.change.abandoned</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -233,7 +233,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.change.created</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -249,7 +249,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.change.merged</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -265,7 +265,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.change.reviewed</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -281,7 +281,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.change.updated</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -297,7 +297,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.environment.created</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -313,7 +313,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.environment.deleted</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -329,7 +329,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.environment.modified</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -345,7 +345,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.incident.detected</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -361,7 +361,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.incident.reported</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -377,7 +377,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.incident.resolved</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -393,7 +393,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.pipelinerun.finished</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -409,7 +409,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.pipelinerun.queued</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -425,7 +425,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.pipelinerun.started</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -441,7 +441,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.repository.created</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -457,7 +457,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.repository.deleted</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -473,7 +473,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.repository.modified</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -489,7 +489,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.service.deployed</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -505,7 +505,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.service.published</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -521,7 +521,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.service.removed</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -537,7 +537,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.service.rolledback</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -553,7 +553,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.service.upgraded</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -569,7 +569,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.taskrun.finished</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -585,7 +585,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.taskrun.started</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -601,7 +601,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.testcaserun.finished</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -617,7 +617,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.testcaserun.queued</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -633,7 +633,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.testcaserun.started</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -649,7 +649,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.testoutput.published</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -665,7 +665,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.testsuiterun.finished</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -681,7 +681,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.testsuiterun.queued</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>
@@ -697,7 +697,7 @@
                             </sourcePaths>
                             <outputDirectory>${sdk.project.dir}/src/main/java</outputDirectory>
                             <targetPackage>dev.cdevents.models.testsuiterun.started</targetPackage>
-                            <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
+                            <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
                             <includeToString>false</includeToString>
                         </configuration>
                     </execution>

--- a/sdk/src/main/java/dev/cdevents/constants/CDEventConstants.java
+++ b/sdk/src/main/java/dev/cdevents/constants/CDEventConstants.java
@@ -1,5 +1,7 @@
 package dev.cdevents.constants;
 
+import dev.cdevents.events.*;
+
 import java.io.File;
 
 public final class CDEventConstants {
@@ -8,14 +10,32 @@ public final class CDEventConstants {
     }
 
     /**
+     * Spec repo location.
+     */
+    public static final String SPEC_REPO = ".." + File.separator + "spec";
+
+    /**
      * Event JsonSchema files location.
      */
-    public static final String SCHEMA_FOLDER = ".." + File.separator + "spec" + File.separator + "schemas";
+    public static final String SCHEMA_FOLDER = SPEC_REPO + File.separator + "schemas";
 
     /**
      * CDEvents Version.
      */
     public static final String CDEVENTS_SPEC_VERSION = "0.3.0";
+
+    /**
+     * CDEvent type prefix.
+     */
+    public static final String EVENT_PREFIX = "dev.cdevents.";
+    /**
+     * CDEvent type subject index.
+     */
+    public static final int EVENT_SUBJECT_INDEX = 2;
+    /**
+     * CDEvent type predicate index.
+     */
+    public static final int EVENT_PREDICATE_INDEX = 3;
 
     public enum Outcome {
         /**
@@ -61,181 +81,181 @@ public final class CDEventConstants {
         /**
          * Pipeline run started event.
          */
-        PipelineRunStartedEvent("dev.cdevents.pipelinerun.started."),
+        PipelineRunStartedEvent("dev.cdevents.pipelinerun.started.", PipelinerunStartedCDEvent.class),
         /**
          * Pipeline run finished event.
          */
-        PipelineRunFinishedEvent("dev.cdevents.pipelinerun.finished."),
+        PipelineRunFinishedEvent("dev.cdevents.pipelinerun.finished.", PipelinerunFinishedCDEvent.class),
         /**
          * Pipeline run queued event.
          */
-        PipelineRunQueuedEvent("dev.cdevents.pipelinerun.queued."),
+        PipelineRunQueuedEvent("dev.cdevents.pipelinerun.queued.", PipelinerunQueuedCDEvent.class),
 
         /* TaskRun events */
         /**
          * Task run started event.
          */
-        TaskRunStartedEvent("dev.cdevents.taskrun.started."),
+        TaskRunStartedEvent("dev.cdevents.taskrun.started.", TaskrunStartedCDEvent.class),
         /**
          * Task run finished event.
          */
-        TaskRunFinishedEvent("dev.cdevents.taskrun.finished."),
+        TaskRunFinishedEvent("dev.cdevents.taskrun.finished.", TaskrunFinishedCDEvent.class),
 
         /* Repository events */
         /**
          * Repository created event.
          */
-        RepositoryCreatedEvent("dev.cdevents.repository.created."),
+        RepositoryCreatedEvent("dev.cdevents.repository.created.", RepositoryCreatedCDEvent.class),
         /**
          * Repository modified event.
          */
-        RepositoryModifiedEvent("dev.cdevents.repository.modified."),
+        RepositoryModifiedEvent("dev.cdevents.repository.modified.", RepositoryModifiedCDEvent.class),
         /**
          * Repository deleted event.
          */
-        RepositoryDeletedEvent("dev.cdevents.repository.deleted."),
+        RepositoryDeletedEvent("dev.cdevents.repository.deleted.", RepositoryDeletedCDEvent.class),
         /**
          * Repository branch created event.
          */
-        BranchCreatedEvent("dev.cdevents.branch.created."),
+        BranchCreatedEvent("dev.cdevents.branch.created.", BranchCreatedCDEvent.class),
         /**
          * Repository branch deleted event.
          */
-        BranchDeletedEvent("dev.cdevents.branch.deleted."),
+        BranchDeletedEvent("dev.cdevents.branch.deleted.", BranchDeletedCDEvent.class),
 
         /* Repository change Events */
         /**
          * Repository change created event.
          */
-        ChangeCreatedEvent("dev.cdevents.change.created."),
+        ChangeCreatedEvent("dev.cdevents.change.created.", ChangeCreatedCDEvent.class),
         /**
          * Repository change updated event.
          */
-        ChangeUpdatedEvent("dev.cdevents.change.updated."),
+        ChangeUpdatedEvent("dev.cdevents.change.updated.", ChangeUpdatedCDEvent.class),
         /**
          * Repository change reviewed event.
          */
-        ChangeReviewedEvent("dev.cdevents.change.reviewed."),
+        ChangeReviewedEvent("dev.cdevents.change.reviewed.", ChangeReviewedCDEvent.class),
         /**
          * Repository change merged event.
          */
-        ChangeMergedEvent("dev.cdevents.change.merged."),
+        ChangeMergedEvent("dev.cdevents.change.merged.", ChangeMergedCDEvent.class),
         /**
          * Repository change abandoned event.
          */
-        ChangeAbandonedEvent("dev.cdevents.change.abandoned."),
+        ChangeAbandonedEvent("dev.cdevents.change.abandoned.", ChangeAbandonedCDEvent.class),
 
         /* Build Events */
         /**
          * Build started event.
          */
-        BuildStartedEvent("dev.cdevents.build.started."),
+        BuildStartedEvent("dev.cdevents.build.started.", BuildStartedCDEvent.class),
         /**
          * Build queued event.
          */
-        BuildQueuedEvent("dev.cdevents.build.queued."),
+        BuildQueuedEvent("dev.cdevents.build.queued.", BuildQueuedCDEvent.class),
         /**
          * Build finished event.
          */
-        BuildFinishedEvent("dev.cdevents.build.finished."),
+        BuildFinishedEvent("dev.cdevents.build.finished.", BuildFinishedCDEvent.class),
 
         /* Test Events */
         /**
          * TestCaseRun started event.
          */
-        TestCaseRunStartedEvent("dev.cdevents.testcaserun.started."),
+        TestCaseRunStartedEvent("dev.cdevents.testcaserun.started.", TestcaserunStartedCDEvent.class),
         /**
          * TestCaseRun queued event.
          */
-        TestCaseRunQueuedEvent("dev.cdevents.testcaserun.queued."),
+        TestCaseRunQueuedEvent("dev.cdevents.testcaserun.queued.", TestcaserunQueuedCDEvent.class),
         /**
          * TestCaseRun finished event.
          */
-        TestCaseRunFinishedEvent("dev.cdevents.testcaserun.finished."),
+        TestCaseRunFinishedEvent("dev.cdevents.testcaserun.finished.", TestcaserunFinishedCDEvent.class),
         /**
          * TestSuiteRun started event.
          */
-        TestSuiteRunStartedEvent("dev.cdevents.testsuiterun.started."),
+        TestSuiteRunStartedEvent("dev.cdevents.testsuiterun.started.", TestsuiterunStartedCDEvent.class),
         /**
          * TestSuiteRun queued event.
          */
-        TestSuiteRunQueuedEvent("dev.cdevents.testsuiterun.queued."),
+        TestSuiteRunQueuedEvent("dev.cdevents.testsuiterun.queued.", TestsuiterunQueuedCDEvent.class),
         /**
          * TestSuiteRun finished event.
          */
-        TestSuiteRunFinishedEvent("dev.cdevents.testsuiterun.finished."),
+        TestSuiteRunFinishedEvent("dev.cdevents.testsuiterun.finished.", TestsuiterunFinishedCDEvent.class),
 
         /**
          * TestOutput published event.
          */
-        TestOutputPublishedEvent("dev.cdevents.testoutput.published."),
+        TestOutputPublishedEvent("dev.cdevents.testoutput.published.", TestoutputPublishedCDEvent.class),
 
         /* Artifact Events */
         /**
          * Artifact packaged event.
          */
-        ArtifactPackagedEvent("dev.cdevents.artifact.packaged."),
+        ArtifactPackagedEvent("dev.cdevents.artifact.packaged.", ArtifactPackagedCDEvent.class),
         /**
          * Artifact published event.
          */
-        ArtifactPublishedEvent("dev.cdevents.artifact.published."),
+        ArtifactPublishedEvent("dev.cdevents.artifact.published.", ArtifactPublishedCDEvent.class),
         /**
          * Artifact signed event.
          */
-        ArtifactSignedEvent("dev.cdevents.artifact.signed."),
+        ArtifactSignedEvent("dev.cdevents.artifact.signed.", ArtifactSignedCDEvent.class),
 
         /* Environment Events */
         /**
          * Environment created event.
          */
-        EnvironmentCreatedEvent("dev.cdevents.environment.created."),
+        EnvironmentCreatedEvent("dev.cdevents.environment.created.", EnvironmentCreatedCDEvent.class),
         /**
          * Environment modified event.
          */
-        EnvironmentModifiedEvent("dev.cdevents.environment.modified."),
+        EnvironmentModifiedEvent("dev.cdevents.environment.modified.", EnvironmentModifiedCDEvent.class),
         /**
          * Environment deleted event.
          */
-        EnvironmentDeletedEvent("dev.cdevents.environment.deleted."),
+        EnvironmentDeletedEvent("dev.cdevents.environment.deleted.", EnvironmentDeletedCDEvent.class),
 
         /* Incident Events */
         /**
          * Incident detected event.
          */
-        IncidentDetectedEvent("dev.cdevents.incident.detected."),
+        IncidentDetectedEvent("dev.cdevents.incident.detected.", IncidentDetectedCDEvent.class),
 
         /**
          * Incident reported event.
          */
-        IncidentReportedEvent("dev.cdevents.incident.reported."),
+        IncidentReportedEvent("dev.cdevents.incident.reported.", IncidentReportedCDEvent.class),
 
         /**
          * Incident resolved event.
          */
-        IncidentResolvedEvent("dev.cdevents.incident.resolved."),
+        IncidentResolvedEvent("dev.cdevents.incident.resolved.", IncidentResolvedCDEvent.class),
 
 
         /* Service Events */
         /**
          * Service deployed event.
          */
-        ServiceDeployedEvent("dev.cdevents.service.deployed."),
+        ServiceDeployedEvent("dev.cdevents.service.deployed.", ServiceDeployedCDEvent.class),
         /**
          * Service upgraded event.
          */
-        ServiceUpgradedEvent("dev.cdevents.service.upgraded."),
+        ServiceUpgradedEvent("dev.cdevents.service.upgraded.", ServiceUpgradedCDEvent.class),
         /**
          * Service rolled back event.
          */
-        ServiceRolledBackEvent("dev.cdevents.service.rolledback."),
+        ServiceRolledBackEvent("dev.cdevents.service.rolledback.", ServiceRolledbackCDEvent.class),
         /**
          * Service removed event.
          */
-        ServiceRemovedEvent("dev.cdevents.service.removed."),
+        ServiceRemovedEvent("dev.cdevents.service.removed.", ServiceRemovedCDEvent.class),
         /**
          * Service published event.
          */
-        ServicePublishedEvent("dev.cdevents.service.published.");
+        ServicePublishedEvent("dev.cdevents.service.published.", ServicePublishedCDEvent.class);
 
 
         /**
@@ -243,8 +263,11 @@ public final class CDEventConstants {
          */
         private String eventType;
 
-        CDEventTypes(final String event) {
+        private Class eventClass;
+
+        CDEventTypes(final String event, final Class eventClass) {
             this.eventType = event;
+            this.eventClass = eventClass;
         }
 
         /**
@@ -261,6 +284,18 @@ public final class CDEventConstants {
             this.eventType = event;
         }
 
+        /**
+         * @return class name of the event type
+         */
+        public Class getEventClass() {
+            return eventClass;
+        }
 
+        /**
+         * @param eventClass class name to set
+         */
+        public void setEventClass(Class eventClass) {
+            this.eventClass = eventClass;
+        }
     }
 }

--- a/sdk/src/main/java/dev/cdevents/models/artifact/packaged/Artifactpackaged.java
+++ b/sdk/src/main/java/dev/cdevents/models/artifact/packaged/Artifactpackaged.java
@@ -8,25 +8,25 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "context",
-    "subject",
-    "customData",
-    "customDataContentType"
+        "context",
+        "subject",
+        "customData",
+        "customDataContentType"
 })
 @Generated("jsonschema2pojo")
 public class Artifactpackaged {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     private Context context;
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     private Subject subject;
@@ -36,9 +36,9 @@ public class Artifactpackaged {
     private String customDataContentType;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public Context getContext() {
@@ -46,9 +46,9 @@ public class Artifactpackaged {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public void setContext(Context context) {
@@ -56,9 +56,9 @@ public class Artifactpackaged {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public Subject getSubject() {
@@ -66,9 +66,9 @@ public class Artifactpackaged {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public void setSubject(Subject subject) {
@@ -93,6 +93,28 @@ public class Artifactpackaged {
     @JsonProperty("customDataContentType")
     public void setCustomDataContentType(String customDataContentType) {
         this.customDataContentType = customDataContentType;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Artifactpackaged) == false) {
+            return false;
+        }
+        Artifactpackaged rhs = ((Artifactpackaged) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/artifact/packaged/Change.java
+++ b/sdk/src/main/java/dev/cdevents/models/artifact/packaged/Change.java
@@ -8,16 +8,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "id",
-    "source"
+        "id",
+        "source"
 })
 @Generated("jsonschema2pojo")
 public class Change {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     private String id;
@@ -25,9 +25,9 @@ public class Change {
     private String source;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public String getId() {
@@ -35,9 +35,9 @@ public class Change {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public void setId(String id) {
@@ -52,6 +52,26 @@ public class Change {
     @JsonProperty("source")
     public void setSource(String source) {
         this.source = source;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Change) == false) {
+            return false;
+        }
+        Change rhs = ((Change) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/artifact/packaged/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/artifact/packaged/Content.java
@@ -41,4 +41,23 @@ public class Content {
         this.change = change;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.change == null)? 0 :this.change.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((this.change == rhs.change)||((this.change!= null)&&this.change.equals(rhs.change)));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/artifact/packaged/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/artifact/packaged/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/artifact/packaged/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/artifact/packaged/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/artifact/published/Artifactpublished.java
+++ b/sdk/src/main/java/dev/cdevents/models/artifact/published/Artifactpublished.java
@@ -8,25 +8,25 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "context",
-    "subject",
-    "customData",
-    "customDataContentType"
+        "context",
+        "subject",
+        "customData",
+        "customDataContentType"
 })
 @Generated("jsonschema2pojo")
 public class Artifactpublished {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     private Context context;
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     private Subject subject;
@@ -36,9 +36,9 @@ public class Artifactpublished {
     private String customDataContentType;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public Context getContext() {
@@ -46,9 +46,9 @@ public class Artifactpublished {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public void setContext(Context context) {
@@ -56,9 +56,9 @@ public class Artifactpublished {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public Subject getSubject() {
@@ -66,9 +66,9 @@ public class Artifactpublished {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public void setSubject(Subject subject) {
@@ -93,6 +93,28 @@ public class Artifactpublished {
     @JsonProperty("customDataContentType")
     public void setCustomDataContentType(String customDataContentType) {
         this.customDataContentType = customDataContentType;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Artifactpublished) == false) {
+            return false;
+        }
+        Artifactpublished rhs = ((Artifactpublished) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/artifact/published/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/artifact/published/Content.java
@@ -13,4 +13,22 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class Content {
 
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return true;
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/artifact/published/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/artifact/published/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/artifact/published/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/artifact/published/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/artifact/signed/Artifactsigned.java
+++ b/sdk/src/main/java/dev/cdevents/models/artifact/signed/Artifactsigned.java
@@ -95,4 +95,26 @@ public class Artifactsigned {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Artifactsigned) == false) {
+            return false;
+        }
+        Artifactsigned rhs = ((Artifactsigned) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/artifact/signed/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/artifact/signed/Content.java
@@ -41,4 +41,23 @@ public class Content {
         this.signature = signature;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.signature == null)? 0 :this.signature.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((this.signature == rhs.signature)||((this.signature!= null)&&this.signature.equals(rhs.signature)));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/artifact/signed/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/artifact/signed/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/artifact/signed/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/artifact/signed/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/branch/created/Branchcreated.java
+++ b/sdk/src/main/java/dev/cdevents/models/branch/created/Branchcreated.java
@@ -8,25 +8,25 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "context",
-    "subject",
-    "customData",
-    "customDataContentType"
+        "context",
+        "subject",
+        "customData",
+        "customDataContentType"
 })
 @Generated("jsonschema2pojo")
 public class Branchcreated {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     private Context context;
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     private Subject subject;
@@ -36,9 +36,9 @@ public class Branchcreated {
     private String customDataContentType;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public Context getContext() {
@@ -46,9 +46,9 @@ public class Branchcreated {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public void setContext(Context context) {
@@ -56,9 +56,9 @@ public class Branchcreated {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public Subject getSubject() {
@@ -66,9 +66,9 @@ public class Branchcreated {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public void setSubject(Subject subject) {
@@ -93,6 +93,28 @@ public class Branchcreated {
     @JsonProperty("customDataContentType")
     public void setCustomDataContentType(String customDataContentType) {
         this.customDataContentType = customDataContentType;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Branchcreated) == false) {
+            return false;
+        }
+        Branchcreated rhs = ((Branchcreated) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/branch/created/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/branch/created/Content.java
@@ -26,4 +26,23 @@ public class Content {
         this.repository = repository;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.repository == null)? 0 :this.repository.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((this.repository == rhs.repository)||((this.repository!= null)&&this.repository.equals(rhs.repository)));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/branch/created/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/branch/created/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/branch/created/Repository.java
+++ b/sdk/src/main/java/dev/cdevents/models/branch/created/Repository.java
@@ -8,16 +8,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "id",
-    "source"
+        "id",
+        "source"
 })
 @Generated("jsonschema2pojo")
 public class Repository {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     private String id;
@@ -25,9 +25,9 @@ public class Repository {
     private String source;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public String getId() {
@@ -35,9 +35,9 @@ public class Repository {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public void setId(String id) {
@@ -52,6 +52,26 @@ public class Repository {
     @JsonProperty("source")
     public void setSource(String source) {
         this.source = source;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Repository) == false) {
+            return false;
+        }
+        Repository rhs = ((Repository) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/branch/created/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/branch/created/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/branch/deleted/Branchdeleted.java
+++ b/sdk/src/main/java/dev/cdevents/models/branch/deleted/Branchdeleted.java
@@ -8,25 +8,25 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "context",
-    "subject",
-    "customData",
-    "customDataContentType"
+        "context",
+        "subject",
+        "customData",
+        "customDataContentType"
 })
 @Generated("jsonschema2pojo")
 public class Branchdeleted {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     private Context context;
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     private Subject subject;
@@ -36,9 +36,9 @@ public class Branchdeleted {
     private String customDataContentType;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public Context getContext() {
@@ -46,9 +46,9 @@ public class Branchdeleted {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public void setContext(Context context) {
@@ -56,9 +56,9 @@ public class Branchdeleted {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public Subject getSubject() {
@@ -66,9 +66,9 @@ public class Branchdeleted {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public void setSubject(Subject subject) {
@@ -93,6 +93,28 @@ public class Branchdeleted {
     @JsonProperty("customDataContentType")
     public void setCustomDataContentType(String customDataContentType) {
         this.customDataContentType = customDataContentType;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Branchdeleted) == false) {
+            return false;
+        }
+        Branchdeleted rhs = ((Branchdeleted) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/branch/deleted/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/branch/deleted/Content.java
@@ -26,4 +26,23 @@ public class Content {
         this.repository = repository;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.repository == null)? 0 :this.repository.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((this.repository == rhs.repository)||((this.repository!= null)&&this.repository.equals(rhs.repository)));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/branch/deleted/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/branch/deleted/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/branch/deleted/Repository.java
+++ b/sdk/src/main/java/dev/cdevents/models/branch/deleted/Repository.java
@@ -8,16 +8,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "id",
-    "source"
+        "id",
+        "source"
 })
 @Generated("jsonschema2pojo")
 public class Repository {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     private String id;
@@ -25,9 +25,9 @@ public class Repository {
     private String source;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public String getId() {
@@ -35,9 +35,9 @@ public class Repository {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public void setId(String id) {
@@ -52,6 +52,26 @@ public class Repository {
     @JsonProperty("source")
     public void setSource(String source) {
         this.source = source;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Repository) == false) {
+            return false;
+        }
+        Repository rhs = ((Repository) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/branch/deleted/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/branch/deleted/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/build/finished/Buildfinished.java
+++ b/sdk/src/main/java/dev/cdevents/models/build/finished/Buildfinished.java
@@ -95,4 +95,26 @@ public class Buildfinished {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Buildfinished) == false) {
+            return false;
+        }
+        Buildfinished rhs = ((Buildfinished) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/build/finished/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/build/finished/Content.java
@@ -26,4 +26,23 @@ public class Content {
         this.artifactId = artifactId;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.artifactId == null)? 0 :this.artifactId.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((this.artifactId == rhs.artifactId)||((this.artifactId!= null)&&this.artifactId.equals(rhs.artifactId)));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/build/finished/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/build/finished/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/build/finished/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/build/finished/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/build/queued/Buildqueued.java
+++ b/sdk/src/main/java/dev/cdevents/models/build/queued/Buildqueued.java
@@ -95,4 +95,26 @@ public class Buildqueued {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Buildqueued) == false) {
+            return false;
+        }
+        Buildqueued rhs = ((Buildqueued) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/build/queued/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/build/queued/Content.java
@@ -13,4 +13,22 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class Content {
 
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return true;
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/build/queued/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/build/queued/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/build/queued/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/build/queued/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/build/started/Buildstarted.java
+++ b/sdk/src/main/java/dev/cdevents/models/build/started/Buildstarted.java
@@ -95,4 +95,26 @@ public class Buildstarted {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Buildstarted) == false) {
+            return false;
+        }
+        Buildstarted rhs = ((Buildstarted) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/build/started/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/build/started/Content.java
@@ -13,4 +13,22 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class Content {
 
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return true;
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/build/started/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/build/started/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/build/started/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/build/started/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/change/abandoned/Changeabandoned.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/abandoned/Changeabandoned.java
@@ -95,4 +95,26 @@ public class Changeabandoned {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Changeabandoned) == false) {
+            return false;
+        }
+        Changeabandoned rhs = ((Changeabandoned) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/abandoned/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/abandoned/Content.java
@@ -26,4 +26,23 @@ public class Content {
         this.repository = repository;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.repository == null)? 0 :this.repository.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((this.repository == rhs.repository)||((this.repository!= null)&&this.repository.equals(rhs.repository)));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/abandoned/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/abandoned/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/change/abandoned/Repository.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/abandoned/Repository.java
@@ -8,16 +8,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "id",
-    "source"
+        "id",
+        "source"
 })
 @Generated("jsonschema2pojo")
 public class Repository {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     private String id;
@@ -25,9 +25,9 @@ public class Repository {
     private String source;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public String getId() {
@@ -35,9 +35,9 @@ public class Repository {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public void setId(String id) {
@@ -52,6 +52,26 @@ public class Repository {
     @JsonProperty("source")
     public void setSource(String source) {
         this.source = source;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Repository) == false) {
+            return false;
+        }
+        Repository rhs = ((Repository) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/abandoned/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/abandoned/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/change/created/Changecreated.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/created/Changecreated.java
@@ -95,4 +95,26 @@ public class Changecreated {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Changecreated) == false) {
+            return false;
+        }
+        Changecreated rhs = ((Changecreated) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/created/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/created/Content.java
@@ -26,4 +26,23 @@ public class Content {
         this.repository = repository;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.repository == null)? 0 :this.repository.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((this.repository == rhs.repository)||((this.repository!= null)&&this.repository.equals(rhs.repository)));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/created/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/created/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/change/created/Repository.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/created/Repository.java
@@ -54,4 +54,24 @@ public class Repository {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Repository) == false) {
+            return false;
+        }
+        Repository rhs = ((Repository) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/created/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/created/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/change/merged/Changemerged.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/merged/Changemerged.java
@@ -95,4 +95,26 @@ public class Changemerged {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Changemerged) == false) {
+            return false;
+        }
+        Changemerged rhs = ((Changemerged) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/merged/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/merged/Content.java
@@ -26,4 +26,23 @@ public class Content {
         this.repository = repository;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.repository == null)? 0 :this.repository.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((this.repository == rhs.repository)||((this.repository!= null)&&this.repository.equals(rhs.repository)));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/merged/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/merged/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/change/merged/Repository.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/merged/Repository.java
@@ -54,4 +54,24 @@ public class Repository {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Repository) == false) {
+            return false;
+        }
+        Repository rhs = ((Repository) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/merged/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/merged/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/change/reviewed/Changereviewed.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/reviewed/Changereviewed.java
@@ -95,4 +95,26 @@ public class Changereviewed {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Changereviewed) == false) {
+            return false;
+        }
+        Changereviewed rhs = ((Changereviewed) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/reviewed/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/reviewed/Content.java
@@ -26,4 +26,23 @@ public class Content {
         this.repository = repository;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.repository == null)? 0 :this.repository.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((this.repository == rhs.repository)||((this.repository!= null)&&this.repository.equals(rhs.repository)));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/reviewed/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/reviewed/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/change/reviewed/Repository.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/reviewed/Repository.java
@@ -54,4 +54,24 @@ public class Repository {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Repository) == false) {
+            return false;
+        }
+        Repository rhs = ((Repository) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/reviewed/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/reviewed/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/change/updated/Changeupdated.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/updated/Changeupdated.java
@@ -95,4 +95,26 @@ public class Changeupdated {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Changeupdated) == false) {
+            return false;
+        }
+        Changeupdated rhs = ((Changeupdated) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/updated/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/updated/Content.java
@@ -26,4 +26,23 @@ public class Content {
         this.repository = repository;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.repository == null)? 0 :this.repository.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((this.repository == rhs.repository)||((this.repository!= null)&&this.repository.equals(rhs.repository)));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/updated/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/updated/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/change/updated/Repository.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/updated/Repository.java
@@ -54,4 +54,24 @@ public class Repository {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Repository) == false) {
+            return false;
+        }
+        Repository rhs = ((Repository) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/change/updated/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/change/updated/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/environment/created/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/environment/created/Content.java
@@ -39,4 +39,24 @@ public class Content {
         this.url = url;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.name == null)? 0 :this.name.hashCode()));
+        result = ((result* 31)+((this.url == null)? 0 :this.url.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/environment/created/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/environment/created/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/environment/created/Environmentcreated.java
+++ b/sdk/src/main/java/dev/cdevents/models/environment/created/Environmentcreated.java
@@ -95,4 +95,26 @@ public class Environmentcreated {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environmentcreated) == false) {
+            return false;
+        }
+        Environmentcreated rhs = ((Environmentcreated) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/environment/created/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/environment/created/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/environment/deleted/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/environment/deleted/Content.java
@@ -26,4 +26,23 @@ public class Content {
         this.name = name;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.name == null)? 0 :this.name.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/environment/deleted/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/environment/deleted/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/environment/deleted/Environmentdeleted.java
+++ b/sdk/src/main/java/dev/cdevents/models/environment/deleted/Environmentdeleted.java
@@ -95,4 +95,26 @@ public class Environmentdeleted {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environmentdeleted) == false) {
+            return false;
+        }
+        Environmentdeleted rhs = ((Environmentdeleted) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/environment/deleted/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/environment/deleted/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/environment/modified/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/environment/modified/Content.java
@@ -39,4 +39,24 @@ public class Content {
         this.url = url;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.name == null)? 0 :this.name.hashCode()));
+        result = ((result* 31)+((this.url == null)? 0 :this.url.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/environment/modified/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/environment/modified/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/environment/modified/Environmentmodified.java
+++ b/sdk/src/main/java/dev/cdevents/models/environment/modified/Environmentmodified.java
@@ -95,4 +95,26 @@ public class Environmentmodified {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environmentmodified) == false) {
+            return false;
+        }
+        Environmentmodified rhs = ((Environmentmodified) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/environment/modified/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/environment/modified/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/incident/detected/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/detected/Content.java
@@ -80,4 +80,26 @@ public class Content {
         this.artifactId = artifactId;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.description == null)? 0 :this.description.hashCode()));
+        result = ((result* 31)+((this.environment == null)? 0 :this.environment.hashCode()));
+        result = ((result* 31)+((this.artifactId == null)? 0 :this.artifactId.hashCode()));
+        result = ((result* 31)+((this.service == null)? 0 :this.service.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((((this.description == rhs.description)||((this.description!= null)&&this.description.equals(rhs.description)))&&((this.environment == rhs.environment)||((this.environment!= null)&&this.environment.equals(rhs.environment))))&&((this.artifactId == rhs.artifactId)||((this.artifactId!= null)&&this.artifactId.equals(rhs.artifactId))))&&((this.service == rhs.service)||((this.service!= null)&&this.service.equals(rhs.service))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/incident/detected/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/detected/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/incident/detected/Environment.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/detected/Environment.java
@@ -8,16 +8,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "id",
-    "source"
+        "id",
+        "source"
 })
 @Generated("jsonschema2pojo")
 public class Environment {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     private String id;
@@ -25,9 +25,9 @@ public class Environment {
     private String source;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public String getId() {
@@ -35,9 +35,9 @@ public class Environment {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public void setId(String id) {
@@ -52,6 +52,26 @@ public class Environment {
     @JsonProperty("source")
     public void setSource(String source) {
         this.source = source;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environment) == false) {
+            return false;
+        }
+        Environment rhs = ((Environment) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/incident/detected/Incidentdetected.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/detected/Incidentdetected.java
@@ -8,25 +8,25 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "context",
-    "subject",
-    "customData",
-    "customDataContentType"
+        "context",
+        "subject",
+        "customData",
+        "customDataContentType"
 })
 @Generated("jsonschema2pojo")
 public class Incidentdetected {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     private Context context;
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     private Subject subject;
@@ -36,9 +36,9 @@ public class Incidentdetected {
     private String customDataContentType;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public Context getContext() {
@@ -46,9 +46,9 @@ public class Incidentdetected {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public void setContext(Context context) {
@@ -56,9 +56,9 @@ public class Incidentdetected {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public Subject getSubject() {
@@ -66,9 +66,9 @@ public class Incidentdetected {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public void setSubject(Subject subject) {
@@ -93,6 +93,28 @@ public class Incidentdetected {
     @JsonProperty("customDataContentType")
     public void setCustomDataContentType(String customDataContentType) {
         this.customDataContentType = customDataContentType;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Incidentdetected) == false) {
+            return false;
+        }
+        Incidentdetected rhs = ((Incidentdetected) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/incident/detected/Service.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/detected/Service.java
@@ -8,16 +8,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "id",
-    "source"
+        "id",
+        "source"
 })
 @Generated("jsonschema2pojo")
 public class Service {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     private String id;
@@ -25,9 +25,9 @@ public class Service {
     private String source;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public String getId() {
@@ -35,9 +35,9 @@ public class Service {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public void setId(String id) {
@@ -52,6 +52,26 @@ public class Service {
     @JsonProperty("source")
     public void setSource(String source) {
         this.source = source;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Service) == false) {
+            return false;
+        }
+        Service rhs = ((Service) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/incident/detected/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/detected/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/incident/reported/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/reported/Content.java
@@ -109,4 +109,27 @@ public class Content {
         this.artifactId = artifactId;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.description == null)? 0 :this.description.hashCode()));
+        result = ((result* 31)+((this.environment == null)? 0 :this.environment.hashCode()));
+        result = ((result* 31)+((this.ticketURI == null)? 0 :this.ticketURI.hashCode()));
+        result = ((result* 31)+((this.artifactId == null)? 0 :this.artifactId.hashCode()));
+        result = ((result* 31)+((this.service == null)? 0 :this.service.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((((((this.description == rhs.description)||((this.description!= null)&&this.description.equals(rhs.description)))&&((this.environment == rhs.environment)||((this.environment!= null)&&this.environment.equals(rhs.environment))))&&((this.ticketURI == rhs.ticketURI)||((this.ticketURI!= null)&&this.ticketURI.equals(rhs.ticketURI))))&&((this.artifactId == rhs.artifactId)||((this.artifactId!= null)&&this.artifactId.equals(rhs.artifactId))))&&((this.service == rhs.service)||((this.service!= null)&&this.service.equals(rhs.service))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/incident/reported/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/reported/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/incident/reported/Environment.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/reported/Environment.java
@@ -8,16 +8,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "id",
-    "source"
+        "id",
+        "source"
 })
 @Generated("jsonschema2pojo")
 public class Environment {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     private String id;
@@ -25,9 +25,9 @@ public class Environment {
     private String source;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public String getId() {
@@ -35,9 +35,9 @@ public class Environment {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public void setId(String id) {
@@ -52,6 +52,26 @@ public class Environment {
     @JsonProperty("source")
     public void setSource(String source) {
         this.source = source;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environment) == false) {
+            return false;
+        }
+        Environment rhs = ((Environment) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/incident/reported/Incidentreported.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/reported/Incidentreported.java
@@ -8,25 +8,25 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "context",
-    "subject",
-    "customData",
-    "customDataContentType"
+        "context",
+        "subject",
+        "customData",
+        "customDataContentType"
 })
 @Generated("jsonschema2pojo")
 public class Incidentreported {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     private Context context;
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     private Subject subject;
@@ -36,9 +36,9 @@ public class Incidentreported {
     private String customDataContentType;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public Context getContext() {
@@ -46,9 +46,9 @@ public class Incidentreported {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public void setContext(Context context) {
@@ -56,9 +56,9 @@ public class Incidentreported {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public Subject getSubject() {
@@ -66,9 +66,9 @@ public class Incidentreported {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public void setSubject(Subject subject) {
@@ -93,6 +93,28 @@ public class Incidentreported {
     @JsonProperty("customDataContentType")
     public void setCustomDataContentType(String customDataContentType) {
         this.customDataContentType = customDataContentType;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Incidentreported) == false) {
+            return false;
+        }
+        Incidentreported rhs = ((Incidentreported) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/incident/reported/Service.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/reported/Service.java
@@ -8,16 +8,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "id",
-    "source"
+        "id",
+        "source"
 })
 @Generated("jsonschema2pojo")
 public class Service {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     private String id;
@@ -25,9 +25,9 @@ public class Service {
     private String source;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public String getId() {
@@ -35,9 +35,9 @@ public class Service {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("id")
     public void setId(String id) {
@@ -52,6 +52,26 @@ public class Service {
     @JsonProperty("source")
     public void setSource(String source) {
         this.source = source;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Service) == false) {
+            return false;
+        }
+        Service rhs = ((Service) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/incident/reported/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/reported/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/incident/resolved/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/resolved/Content.java
@@ -80,4 +80,26 @@ public class Content {
         this.artifactId = artifactId;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.description == null)? 0 :this.description.hashCode()));
+        result = ((result* 31)+((this.environment == null)? 0 :this.environment.hashCode()));
+        result = ((result* 31)+((this.artifactId == null)? 0 :this.artifactId.hashCode()));
+        result = ((result* 31)+((this.service == null)? 0 :this.service.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((((this.description == rhs.description)||((this.description!= null)&&this.description.equals(rhs.description)))&&((this.environment == rhs.environment)||((this.environment!= null)&&this.environment.equals(rhs.environment))))&&((this.artifactId == rhs.artifactId)||((this.artifactId!= null)&&this.artifactId.equals(rhs.artifactId))))&&((this.service == rhs.service)||((this.service!= null)&&this.service.equals(rhs.service))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/incident/resolved/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/resolved/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/incident/resolved/Environment.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/resolved/Environment.java
@@ -54,4 +54,24 @@ public class Environment {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environment) == false) {
+            return false;
+        }
+        Environment rhs = ((Environment) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/incident/resolved/Incidentresolved.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/resolved/Incidentresolved.java
@@ -8,25 +8,25 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "context",
-    "subject",
-    "customData",
-    "customDataContentType"
+        "context",
+        "subject",
+        "customData",
+        "customDataContentType"
 })
 @Generated("jsonschema2pojo")
 public class Incidentresolved {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     private Context context;
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     private Subject subject;
@@ -36,9 +36,9 @@ public class Incidentresolved {
     private String customDataContentType;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public Context getContext() {
@@ -46,9 +46,9 @@ public class Incidentresolved {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public void setContext(Context context) {
@@ -56,9 +56,9 @@ public class Incidentresolved {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public Subject getSubject() {
@@ -66,9 +66,9 @@ public class Incidentresolved {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public void setSubject(Subject subject) {
@@ -93,6 +93,28 @@ public class Incidentresolved {
     @JsonProperty("customDataContentType")
     public void setCustomDataContentType(String customDataContentType) {
         this.customDataContentType = customDataContentType;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Incidentresolved) == false) {
+            return false;
+        }
+        Incidentresolved rhs = ((Incidentresolved) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/incident/resolved/Service.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/resolved/Service.java
@@ -54,4 +54,24 @@ public class Service {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Service) == false) {
+            return false;
+        }
+        Service rhs = ((Service) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/incident/resolved/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/incident/resolved/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/pipelinerun/finished/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/pipelinerun/finished/Content.java
@@ -65,4 +65,26 @@ public class Content {
         this.errors = errors;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.pipelineName == null)? 0 :this.pipelineName.hashCode()));
+        result = ((result* 31)+((this.url == null)? 0 :this.url.hashCode()));
+        result = ((result* 31)+((this.outcome == null)? 0 :this.outcome.hashCode()));
+        result = ((result* 31)+((this.errors == null)? 0 :this.errors.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((((this.pipelineName == rhs.pipelineName)||((this.pipelineName!= null)&&this.pipelineName.equals(rhs.pipelineName)))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))))&&((this.outcome == rhs.outcome)||((this.outcome!= null)&&this.outcome.equals(rhs.outcome))))&&((this.errors == rhs.errors)||((this.errors!= null)&&this.errors.equals(rhs.errors))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/pipelinerun/finished/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/pipelinerun/finished/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/pipelinerun/finished/Pipelinerunfinished.java
+++ b/sdk/src/main/java/dev/cdevents/models/pipelinerun/finished/Pipelinerunfinished.java
@@ -95,4 +95,26 @@ public class Pipelinerunfinished {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Pipelinerunfinished) == false) {
+            return false;
+        }
+        Pipelinerunfinished rhs = ((Pipelinerunfinished) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/pipelinerun/finished/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/pipelinerun/finished/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/pipelinerun/queued/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/pipelinerun/queued/Content.java
@@ -39,4 +39,24 @@ public class Content {
         this.url = url;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.pipelineName == null)? 0 :this.pipelineName.hashCode()));
+        result = ((result* 31)+((this.url == null)? 0 :this.url.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((this.pipelineName == rhs.pipelineName)||((this.pipelineName!= null)&&this.pipelineName.equals(rhs.pipelineName)))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/pipelinerun/queued/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/pipelinerun/queued/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/pipelinerun/queued/Pipelinerunqueued.java
+++ b/sdk/src/main/java/dev/cdevents/models/pipelinerun/queued/Pipelinerunqueued.java
@@ -95,4 +95,26 @@ public class Pipelinerunqueued {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Pipelinerunqueued) == false) {
+            return false;
+        }
+        Pipelinerunqueued rhs = ((Pipelinerunqueued) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/pipelinerun/queued/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/pipelinerun/queued/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/pipelinerun/started/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/pipelinerun/started/Content.java
@@ -69,4 +69,24 @@ public class Content {
         this.url = url;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.pipelineName == null)? 0 :this.pipelineName.hashCode()));
+        result = ((result* 31)+((this.url == null)? 0 :this.url.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((this.pipelineName == rhs.pipelineName)||((this.pipelineName!= null)&&this.pipelineName.equals(rhs.pipelineName)))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/pipelinerun/started/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/pipelinerun/started/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/pipelinerun/started/Pipelinerunstarted.java
+++ b/sdk/src/main/java/dev/cdevents/models/pipelinerun/started/Pipelinerunstarted.java
@@ -95,4 +95,26 @@ public class Pipelinerunstarted {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Pipelinerunstarted) == false) {
+            return false;
+        }
+        Pipelinerunstarted rhs = ((Pipelinerunstarted) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/pipelinerun/started/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/pipelinerun/started/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/repository/created/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/repository/created/Content.java
@@ -95,4 +95,26 @@ public class Content {
         this.viewUrl = viewUrl;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.name == null)? 0 :this.name.hashCode()));
+        result = ((result* 31)+((this.owner == null)? 0 :this.owner.hashCode()));
+        result = ((result* 31)+((this.viewUrl == null)? 0 :this.viewUrl.hashCode()));
+        result = ((result* 31)+((this.url == null)? 0 :this.url.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.owner == rhs.owner)||((this.owner!= null)&&this.owner.equals(rhs.owner))))&&((this.viewUrl == rhs.viewUrl)||((this.viewUrl!= null)&&this.viewUrl.equals(rhs.viewUrl))))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/repository/created/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/repository/created/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/repository/created/Repositorycreated.java
+++ b/sdk/src/main/java/dev/cdevents/models/repository/created/Repositorycreated.java
@@ -95,4 +95,26 @@ public class Repositorycreated {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Repositorycreated) == false) {
+            return false;
+        }
+        Repositorycreated rhs = ((Repositorycreated) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/repository/created/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/repository/created/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/repository/deleted/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/repository/deleted/Content.java
@@ -65,4 +65,26 @@ public class Content {
         this.viewUrl = viewUrl;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.name == null)? 0 :this.name.hashCode()));
+        result = ((result* 31)+((this.owner == null)? 0 :this.owner.hashCode()));
+        result = ((result* 31)+((this.viewUrl == null)? 0 :this.viewUrl.hashCode()));
+        result = ((result* 31)+((this.url == null)? 0 :this.url.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.owner == rhs.owner)||((this.owner!= null)&&this.owner.equals(rhs.owner))))&&((this.viewUrl == rhs.viewUrl)||((this.viewUrl!= null)&&this.viewUrl.equals(rhs.viewUrl))))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/repository/deleted/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/repository/deleted/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/repository/deleted/Repositorydeleted.java
+++ b/sdk/src/main/java/dev/cdevents/models/repository/deleted/Repositorydeleted.java
@@ -95,4 +95,26 @@ public class Repositorydeleted {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Repositorydeleted) == false) {
+            return false;
+        }
+        Repositorydeleted rhs = ((Repositorydeleted) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/repository/deleted/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/repository/deleted/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/repository/modified/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/repository/modified/Content.java
@@ -65,4 +65,26 @@ public class Content {
         this.viewUrl = viewUrl;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.name == null)? 0 :this.name.hashCode()));
+        result = ((result* 31)+((this.owner == null)? 0 :this.owner.hashCode()));
+        result = ((result* 31)+((this.viewUrl == null)? 0 :this.viewUrl.hashCode()));
+        result = ((result* 31)+((this.url == null)? 0 :this.url.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.owner == rhs.owner)||((this.owner!= null)&&this.owner.equals(rhs.owner))))&&((this.viewUrl == rhs.viewUrl)||((this.viewUrl!= null)&&this.viewUrl.equals(rhs.viewUrl))))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/repository/modified/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/repository/modified/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/repository/modified/Repositorymodified.java
+++ b/sdk/src/main/java/dev/cdevents/models/repository/modified/Repositorymodified.java
@@ -95,4 +95,26 @@ public class Repositorymodified {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Repositorymodified) == false) {
+            return false;
+        }
+        Repositorymodified rhs = ((Repositorymodified) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/repository/modified/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/repository/modified/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/service/deployed/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/deployed/Content.java
@@ -69,4 +69,24 @@ public class Content {
         this.artifactId = artifactId;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.environment == null)? 0 :this.environment.hashCode()));
+        result = ((result* 31)+((this.artifactId == null)? 0 :this.artifactId.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((this.environment == rhs.environment)||((this.environment!= null)&&this.environment.equals(rhs.environment)))&&((this.artifactId == rhs.artifactId)||((this.artifactId!= null)&&this.artifactId.equals(rhs.artifactId))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/deployed/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/deployed/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/service/deployed/Environment.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/deployed/Environment.java
@@ -54,4 +54,24 @@ public class Environment {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environment) == false) {
+            return false;
+        }
+        Environment rhs = ((Environment) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/deployed/Servicedeployed.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/deployed/Servicedeployed.java
@@ -95,4 +95,26 @@ public class Servicedeployed {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Servicedeployed) == false) {
+            return false;
+        }
+        Servicedeployed rhs = ((Servicedeployed) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/deployed/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/deployed/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/service/published/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/published/Content.java
@@ -26,4 +26,23 @@ public class Content {
         this.environment = environment;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.environment == null)? 0 :this.environment.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((this.environment == rhs.environment)||((this.environment!= null)&&this.environment.equals(rhs.environment)));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/published/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/published/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/service/published/Environment.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/published/Environment.java
@@ -54,4 +54,24 @@ public class Environment {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environment) == false) {
+            return false;
+        }
+        Environment rhs = ((Environment) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/published/Servicepublished.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/published/Servicepublished.java
@@ -95,4 +95,26 @@ public class Servicepublished {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Servicepublished) == false) {
+            return false;
+        }
+        Servicepublished rhs = ((Servicepublished) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/published/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/published/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/service/removed/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/removed/Content.java
@@ -26,4 +26,23 @@ public class Content {
         this.environment = environment;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.environment == null)? 0 :this.environment.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((this.environment == rhs.environment)||((this.environment!= null)&&this.environment.equals(rhs.environment)));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/removed/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/removed/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/service/removed/Environment.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/removed/Environment.java
@@ -54,4 +54,24 @@ public class Environment {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environment) == false) {
+            return false;
+        }
+        Environment rhs = ((Environment) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/removed/Serviceremoved.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/removed/Serviceremoved.java
@@ -95,4 +95,26 @@ public class Serviceremoved {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Serviceremoved) == false) {
+            return false;
+        }
+        Serviceremoved rhs = ((Serviceremoved) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/removed/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/removed/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/service/rolledback/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/rolledback/Content.java
@@ -69,4 +69,24 @@ public class Content {
         this.artifactId = artifactId;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.environment == null)? 0 :this.environment.hashCode()));
+        result = ((result* 31)+((this.artifactId == null)? 0 :this.artifactId.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((this.environment == rhs.environment)||((this.environment!= null)&&this.environment.equals(rhs.environment)))&&((this.artifactId == rhs.artifactId)||((this.artifactId!= null)&&this.artifactId.equals(rhs.artifactId))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/rolledback/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/rolledback/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/service/rolledback/Environment.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/rolledback/Environment.java
@@ -54,4 +54,24 @@ public class Environment {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environment) == false) {
+            return false;
+        }
+        Environment rhs = ((Environment) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/rolledback/Servicerolledback.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/rolledback/Servicerolledback.java
@@ -95,4 +95,26 @@ public class Servicerolledback {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Servicerolledback) == false) {
+            return false;
+        }
+        Servicerolledback rhs = ((Servicerolledback) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/rolledback/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/rolledback/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/service/upgraded/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/upgraded/Content.java
@@ -69,4 +69,24 @@ public class Content {
         this.artifactId = artifactId;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.environment == null)? 0 :this.environment.hashCode()));
+        result = ((result* 31)+((this.artifactId == null)? 0 :this.artifactId.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((this.environment == rhs.environment)||((this.environment!= null)&&this.environment.equals(rhs.environment)))&&((this.artifactId == rhs.artifactId)||((this.artifactId!= null)&&this.artifactId.equals(rhs.artifactId))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/upgraded/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/upgraded/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/service/upgraded/Environment.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/upgraded/Environment.java
@@ -54,4 +54,24 @@ public class Environment {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environment) == false) {
+            return false;
+        }
+        Environment rhs = ((Environment) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/upgraded/Serviceupgraded.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/upgraded/Serviceupgraded.java
@@ -95,4 +95,26 @@ public class Serviceupgraded {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Serviceupgraded) == false) {
+            return false;
+        }
+        Serviceupgraded rhs = ((Serviceupgraded) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/service/upgraded/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/service/upgraded/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/taskrun/finished/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/taskrun/finished/Content.java
@@ -78,4 +78,27 @@ public class Content {
         this.errors = errors;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.taskName == null)? 0 :this.taskName.hashCode()));
+        result = ((result* 31)+((this.url == null)? 0 :this.url.hashCode()));
+        result = ((result* 31)+((this.pipelineRun == null)? 0 :this.pipelineRun.hashCode()));
+        result = ((result* 31)+((this.outcome == null)? 0 :this.outcome.hashCode()));
+        result = ((result* 31)+((this.errors == null)? 0 :this.errors.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((((((this.taskName == rhs.taskName)||((this.taskName!= null)&&this.taskName.equals(rhs.taskName)))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))))&&((this.pipelineRun == rhs.pipelineRun)||((this.pipelineRun!= null)&&this.pipelineRun.equals(rhs.pipelineRun))))&&((this.outcome == rhs.outcome)||((this.outcome!= null)&&this.outcome.equals(rhs.outcome))))&&((this.errors == rhs.errors)||((this.errors!= null)&&this.errors.equals(rhs.errors))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/taskrun/finished/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/taskrun/finished/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/taskrun/finished/PipelineRun.java
+++ b/sdk/src/main/java/dev/cdevents/models/taskrun/finished/PipelineRun.java
@@ -54,4 +54,24 @@ public class PipelineRun {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof PipelineRun) == false) {
+            return false;
+        }
+        PipelineRun rhs = ((PipelineRun) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/taskrun/finished/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/taskrun/finished/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/taskrun/finished/Taskrunfinished.java
+++ b/sdk/src/main/java/dev/cdevents/models/taskrun/finished/Taskrunfinished.java
@@ -95,4 +95,26 @@ public class Taskrunfinished {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Taskrunfinished) == false) {
+            return false;
+        }
+        Taskrunfinished rhs = ((Taskrunfinished) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/taskrun/started/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/taskrun/started/Content.java
@@ -52,4 +52,25 @@ public class Content {
         this.pipelineRun = pipelineRun;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.taskName == null)? 0 :this.taskName.hashCode()));
+        result = ((result* 31)+((this.url == null)? 0 :this.url.hashCode()));
+        result = ((result* 31)+((this.pipelineRun == null)? 0 :this.pipelineRun.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((((this.taskName == rhs.taskName)||((this.taskName!= null)&&this.taskName.equals(rhs.taskName)))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))))&&((this.pipelineRun == rhs.pipelineRun)||((this.pipelineRun!= null)&&this.pipelineRun.equals(rhs.pipelineRun))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/taskrun/started/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/taskrun/started/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/taskrun/started/PipelineRun.java
+++ b/sdk/src/main/java/dev/cdevents/models/taskrun/started/PipelineRun.java
@@ -54,4 +54,24 @@ public class PipelineRun {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof PipelineRun) == false) {
+            return false;
+        }
+        PipelineRun rhs = ((PipelineRun) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/taskrun/started/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/taskrun/started/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/taskrun/started/Taskrunstarted.java
+++ b/sdk/src/main/java/dev/cdevents/models/taskrun/started/Taskrunstarted.java
@@ -95,4 +95,26 @@ public class Taskrunstarted {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Taskrunstarted) == false) {
+            return false;
+        }
+        Taskrunstarted rhs = ((Taskrunstarted) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/finished/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/finished/Content.java
@@ -125,6 +125,30 @@ public class Content {
         this.testCase = testCase;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.severity == null)? 0 :this.severity.hashCode()));
+        result = ((result* 31)+((this.reason == null)? 0 :this.reason.hashCode()));
+        result = ((result* 31)+((this.environment == null)? 0 :this.environment.hashCode()));
+        result = ((result* 31)+((this.testSuiteRun == null)? 0 :this.testSuiteRun.hashCode()));
+        result = ((result* 31)+((this.outcome == null)? 0 :this.outcome.hashCode()));
+        result = ((result* 31)+((this.testCase == null)? 0 :this.testCase.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((((((this.severity == rhs.severity)||((this.severity!= null)&&this.severity.equals(rhs.severity)))&&((this.reason == rhs.reason)||((this.reason!= null)&&this.reason.equals(rhs.reason))))&&((this.environment == rhs.environment)||((this.environment!= null)&&this.environment.equals(rhs.environment))))&&((this.testSuiteRun == rhs.testSuiteRun)||((this.testSuiteRun!= null)&&this.testSuiteRun.equals(rhs.testSuiteRun))))&&((this.outcome == rhs.outcome)||((this.outcome!= null)&&this.outcome.equals(rhs.outcome))))&&((this.testCase == rhs.testCase)||((this.testCase!= null)&&this.testCase.equals(rhs.testCase))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Outcome {
 

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/finished/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/finished/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/finished/Environment.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/finished/Environment.java
@@ -54,4 +54,24 @@ public class Environment {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environment) == false) {
+            return false;
+        }
+        Environment rhs = ((Environment) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/finished/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/finished/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/finished/TestCase.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/finished/TestCase.java
@@ -98,6 +98,29 @@ public class TestCase {
         this.uri = uri;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.name == null)? 0 :this.name.hashCode()));
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.uri == null)? 0 :this.uri.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof TestCase) == false) {
+            return false;
+        }
+        TestCase rhs = ((TestCase) other);
+        return ((((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.uri == rhs.uri)||((this.uri!= null)&&this.uri.equals(rhs.uri))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/finished/TestSuiteRun.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/finished/TestSuiteRun.java
@@ -54,4 +54,24 @@ public class TestSuiteRun {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof TestSuiteRun) == false) {
+            return false;
+        }
+        TestSuiteRun rhs = ((TestSuiteRun) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/finished/Testcaserunfinished.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/finished/Testcaserunfinished.java
@@ -95,4 +95,26 @@ public class Testcaserunfinished {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Testcaserunfinished) == false) {
+            return false;
+        }
+        Testcaserunfinished rhs = ((Testcaserunfinished) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/Content.java
@@ -80,4 +80,26 @@ public class Content {
         this.testCase = testCase;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.environment == null)? 0 :this.environment.hashCode()));
+        result = ((result* 31)+((this.trigger == null)? 0 :this.trigger.hashCode()));
+        result = ((result* 31)+((this.testSuiteRun == null)? 0 :this.testSuiteRun.hashCode()));
+        result = ((result* 31)+((this.testCase == null)? 0 :this.testCase.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((((this.environment == rhs.environment)||((this.environment!= null)&&this.environment.equals(rhs.environment)))&&((this.trigger == rhs.trigger)||((this.trigger!= null)&&this.trigger.equals(rhs.trigger))))&&((this.testSuiteRun == rhs.testSuiteRun)||((this.testSuiteRun!= null)&&this.testSuiteRun.equals(rhs.testSuiteRun))))&&((this.testCase == rhs.testCase)||((this.testCase!= null)&&this.testCase.equals(rhs.testCase))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/Environment.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/Environment.java
@@ -54,4 +54,24 @@ public class Environment {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environment) == false) {
+            return false;
+        }
+        Environment rhs = ((Environment) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/TestCase.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/TestCase.java
@@ -98,6 +98,29 @@ public class TestCase {
         this.uri = uri;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.name == null)? 0 :this.name.hashCode()));
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.uri == null)? 0 :this.uri.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof TestCase) == false) {
+            return false;
+        }
+        TestCase rhs = ((TestCase) other);
+        return ((((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.uri == rhs.uri)||((this.uri!= null)&&this.uri.equals(rhs.uri))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/TestSuiteRun.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/TestSuiteRun.java
@@ -54,4 +54,24 @@ public class TestSuiteRun {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof TestSuiteRun) == false) {
+            return false;
+        }
+        TestSuiteRun rhs = ((TestSuiteRun) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/Testcaserunqueued.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/Testcaserunqueued.java
@@ -8,25 +8,25 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "context",
-    "subject",
-    "customData",
-    "customDataContentType"
+        "context",
+        "subject",
+        "customData",
+        "customDataContentType"
 })
 @Generated("jsonschema2pojo")
 public class Testcaserunqueued {
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     private Context context;
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     private Subject subject;
@@ -36,9 +36,9 @@ public class Testcaserunqueued {
     private String customDataContentType;
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public Context getContext() {
@@ -46,9 +46,9 @@ public class Testcaserunqueued {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("context")
     public void setContext(Context context) {
@@ -56,9 +56,9 @@ public class Testcaserunqueued {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public Subject getSubject() {
@@ -66,9 +66,9 @@ public class Testcaserunqueued {
     }
 
     /**
-     * 
+     *
      * (Required)
-     * 
+     *
      */
     @JsonProperty("subject")
     public void setSubject(Subject subject) {
@@ -93,6 +93,28 @@ public class Testcaserunqueued {
     @JsonProperty("customDataContentType")
     public void setCustomDataContentType(String customDataContentType) {
         this.customDataContentType = customDataContentType;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Testcaserunqueued) == false) {
+            return false;
+        }
+        Testcaserunqueued rhs = ((Testcaserunqueued) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
     }
 
 }

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/Trigger.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/queued/Trigger.java
@@ -60,6 +60,27 @@ public class Trigger {
         this.additionalProperties.put(name, value);
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.uri == null)? 0 :this.uri.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Trigger) == false) {
+            return false;
+        }
+        Trigger rhs = ((Trigger) other);
+        return ((((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties)))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.uri == rhs.uri)||((this.uri!= null)&&this.uri.equals(rhs.uri))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/started/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/started/Content.java
@@ -80,4 +80,26 @@ public class Content {
         this.testCase = testCase;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.environment == null)? 0 :this.environment.hashCode()));
+        result = ((result* 31)+((this.trigger == null)? 0 :this.trigger.hashCode()));
+        result = ((result* 31)+((this.testSuiteRun == null)? 0 :this.testSuiteRun.hashCode()));
+        result = ((result* 31)+((this.testCase == null)? 0 :this.testCase.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((((this.environment == rhs.environment)||((this.environment!= null)&&this.environment.equals(rhs.environment)))&&((this.trigger == rhs.trigger)||((this.trigger!= null)&&this.trigger.equals(rhs.trigger))))&&((this.testSuiteRun == rhs.testSuiteRun)||((this.testSuiteRun!= null)&&this.testSuiteRun.equals(rhs.testSuiteRun))))&&((this.testCase == rhs.testCase)||((this.testCase!= null)&&this.testCase.equals(rhs.testCase))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/started/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/started/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/started/Environment.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/started/Environment.java
@@ -54,4 +54,24 @@ public class Environment {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environment) == false) {
+            return false;
+        }
+        Environment rhs = ((Environment) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/started/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/started/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/started/TestCase.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/started/TestCase.java
@@ -98,6 +98,29 @@ public class TestCase {
         this.uri = uri;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.name == null)? 0 :this.name.hashCode()));
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.uri == null)? 0 :this.uri.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof TestCase) == false) {
+            return false;
+        }
+        TestCase rhs = ((TestCase) other);
+        return ((((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.uri == rhs.uri)||((this.uri!= null)&&this.uri.equals(rhs.uri))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/started/TestSuiteRun.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/started/TestSuiteRun.java
@@ -54,4 +54,24 @@ public class TestSuiteRun {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof TestSuiteRun) == false) {
+            return false;
+        }
+        TestSuiteRun rhs = ((TestSuiteRun) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/started/Testcaserunstarted.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/started/Testcaserunstarted.java
@@ -95,4 +95,26 @@ public class Testcaserunstarted {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Testcaserunstarted) == false) {
+            return false;
+        }
+        Testcaserunstarted rhs = ((Testcaserunstarted) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testcaserun/started/Trigger.java
+++ b/sdk/src/main/java/dev/cdevents/models/testcaserun/started/Trigger.java
@@ -60,6 +60,27 @@ public class Trigger {
         this.additionalProperties.put(name, value);
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.uri == null)? 0 :this.uri.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Trigger) == false) {
+            return false;
+        }
+        Trigger rhs = ((Trigger) other);
+        return ((((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties)))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.uri == rhs.uri)||((this.uri!= null)&&this.uri.equals(rhs.uri))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testoutput/published/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/testoutput/published/Content.java
@@ -100,6 +100,28 @@ public class Content {
         this.testCaseRun = testCaseRun;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.format == null)? 0 :this.format.hashCode()));
+        result = ((result* 31)+((this.outputType == null)? 0 :this.outputType.hashCode()));
+        result = ((result* 31)+((this.uri == null)? 0 :this.uri.hashCode()));
+        result = ((result* 31)+((this.testCaseRun == null)? 0 :this.testCaseRun.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return (((((this.format == rhs.format)||((this.format!= null)&&this.format.equals(rhs.format)))&&((this.outputType == rhs.outputType)||((this.outputType!= null)&&this.outputType.equals(rhs.outputType))))&&((this.uri == rhs.uri)||((this.uri!= null)&&this.uri.equals(rhs.uri))))&&((this.testCaseRun == rhs.testCaseRun)||((this.testCaseRun!= null)&&this.testCaseRun.equals(rhs.testCaseRun))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum OutputType {
 

--- a/sdk/src/main/java/dev/cdevents/models/testoutput/published/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/testoutput/published/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testoutput/published/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/testoutput/published/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testoutput/published/TestCaseRun.java
+++ b/sdk/src/main/java/dev/cdevents/models/testoutput/published/TestCaseRun.java
@@ -54,4 +54,24 @@ public class TestCaseRun {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof TestCaseRun) == false) {
+            return false;
+        }
+        TestCaseRun rhs = ((TestCaseRun) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testoutput/published/Testoutputpublished.java
+++ b/sdk/src/main/java/dev/cdevents/models/testoutput/published/Testoutputpublished.java
@@ -95,4 +95,26 @@ public class Testoutputpublished {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Testoutputpublished) == false) {
+            return false;
+        }
+        Testoutputpublished rhs = ((Testoutputpublished) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/finished/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/finished/Content.java
@@ -112,6 +112,29 @@ public class Content {
         this.reason = reason;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.severity == null)? 0 :this.severity.hashCode()));
+        result = ((result* 31)+((this.reason == null)? 0 :this.reason.hashCode()));
+        result = ((result* 31)+((this.environment == null)? 0 :this.environment.hashCode()));
+        result = ((result* 31)+((this.testSuite == null)? 0 :this.testSuite.hashCode()));
+        result = ((result* 31)+((this.outcome == null)? 0 :this.outcome.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((((((this.severity == rhs.severity)||((this.severity!= null)&&this.severity.equals(rhs.severity)))&&((this.reason == rhs.reason)||((this.reason!= null)&&this.reason.equals(rhs.reason))))&&((this.environment == rhs.environment)||((this.environment!= null)&&this.environment.equals(rhs.environment))))&&((this.testSuite == rhs.testSuite)||((this.testSuite!= null)&&this.testSuite.equals(rhs.testSuite))))&&((this.outcome == rhs.outcome)||((this.outcome!= null)&&this.outcome.equals(rhs.outcome))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Outcome {
 

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/finished/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/finished/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/finished/Environment.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/finished/Environment.java
@@ -54,4 +54,24 @@ public class Environment {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environment) == false) {
+            return false;
+        }
+        Environment rhs = ((Environment) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/finished/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/finished/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/finished/TestSuite.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/finished/TestSuite.java
@@ -81,4 +81,26 @@ public class TestSuite {
         this.uri = uri;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.name == null)? 0 :this.name.hashCode()));
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.uri == null)? 0 :this.uri.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof TestSuite) == false) {
+            return false;
+        }
+        TestSuite rhs = ((TestSuite) other);
+        return (((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.uri == rhs.uri)||((this.uri!= null)&&this.uri.equals(rhs.uri))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/finished/Testsuiterunfinished.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/finished/Testsuiterunfinished.java
@@ -95,4 +95,26 @@ public class Testsuiterunfinished {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Testsuiterunfinished) == false) {
+            return false;
+        }
+        Testsuiterunfinished rhs = ((Testsuiterunfinished) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/queued/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/queued/Content.java
@@ -67,4 +67,25 @@ public class Content {
         this.testSuite = testSuite;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.environment == null)? 0 :this.environment.hashCode()));
+        result = ((result* 31)+((this.trigger == null)? 0 :this.trigger.hashCode()));
+        result = ((result* 31)+((this.testSuite == null)? 0 :this.testSuite.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((((this.environment == rhs.environment)||((this.environment!= null)&&this.environment.equals(rhs.environment)))&&((this.trigger == rhs.trigger)||((this.trigger!= null)&&this.trigger.equals(rhs.trigger))))&&((this.testSuite == rhs.testSuite)||((this.testSuite!= null)&&this.testSuite.equals(rhs.testSuite))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/queued/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/queued/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/queued/Environment.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/queued/Environment.java
@@ -54,4 +54,24 @@ public class Environment {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environment) == false) {
+            return false;
+        }
+        Environment rhs = ((Environment) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/queued/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/queued/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/queued/TestSuite.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/queued/TestSuite.java
@@ -81,4 +81,26 @@ public class TestSuite {
         this.url = url;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.name == null)? 0 :this.name.hashCode()));
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.url == null)? 0 :this.url.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof TestSuite) == false) {
+            return false;
+        }
+        TestSuite rhs = ((TestSuite) other);
+        return (((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.url == rhs.url)||((this.url!= null)&&this.url.equals(rhs.url))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/queued/Testsuiterunqueued.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/queued/Testsuiterunqueued.java
@@ -95,4 +95,26 @@ public class Testsuiterunqueued {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Testsuiterunqueued) == false) {
+            return false;
+        }
+        Testsuiterunqueued rhs = ((Testsuiterunqueued) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/queued/Trigger.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/queued/Trigger.java
@@ -60,6 +60,27 @@ public class Trigger {
         this.additionalProperties.put(name, value);
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.uri == null)? 0 :this.uri.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Trigger) == false) {
+            return false;
+        }
+        Trigger rhs = ((Trigger) other);
+        return ((((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties)))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.uri == rhs.uri)||((this.uri!= null)&&this.uri.equals(rhs.uri))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/started/Content.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/started/Content.java
@@ -67,4 +67,25 @@ public class Content {
         this.testSuite = testSuite;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.environment == null)? 0 :this.environment.hashCode()));
+        result = ((result* 31)+((this.trigger == null)? 0 :this.trigger.hashCode()));
+        result = ((result* 31)+((this.testSuite == null)? 0 :this.testSuite.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Content) == false) {
+            return false;
+        }
+        Content rhs = ((Content) other);
+        return ((((this.environment == rhs.environment)||((this.environment!= null)&&this.environment.equals(rhs.environment)))&&((this.trigger == rhs.trigger)||((this.trigger!= null)&&this.trigger.equals(rhs.trigger))))&&((this.testSuite == rhs.testSuite)||((this.testSuite!= null)&&this.testSuite.equals(rhs.testSuite))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/started/Context.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/started/Context.java
@@ -158,6 +158,29 @@ public class Context {
         this.timestamp = timestamp;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.timestamp == null)? 0 :this.timestamp.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Context) == false) {
+            return false;
+        }
+        Context rhs = ((Context) other);
+        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/started/Environment.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/started/Environment.java
@@ -54,4 +54,24 @@ public class Environment {
         this.source = source;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Environment) == false) {
+            return false;
+        }
+        Environment rhs = ((Environment) other);
+        return (((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/started/Subject.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/started/Subject.java
@@ -114,6 +114,28 @@ public class Subject {
         this.content = content;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.source == null)? 0 :this.source.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.content == null)? 0 :this.content.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Subject) == false) {
+            return false;
+        }
+        Subject rhs = ((Subject) other);
+        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.source == rhs.source)||((this.source!= null)&&this.source.equals(rhs.source))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.content == rhs.content)||((this.content!= null)&&this.content.equals(rhs.content))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/started/TestSuite.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/started/TestSuite.java
@@ -81,4 +81,26 @@ public class TestSuite {
         this.uri = uri;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.name == null)? 0 :this.name.hashCode()));
+        result = ((result* 31)+((this.id == null)? 0 :this.id.hashCode()));
+        result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
+        result = ((result* 31)+((this.uri == null)? 0 :this.uri.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof TestSuite) == false) {
+            return false;
+        }
+        TestSuite rhs = ((TestSuite) other);
+        return (((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.uri == rhs.uri)||((this.uri!= null)&&this.uri.equals(rhs.uri))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/started/Testsuiterunstarted.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/started/Testsuiterunstarted.java
@@ -95,4 +95,26 @@ public class Testsuiterunstarted {
         this.customDataContentType = customDataContentType;
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.context == null)? 0 :this.context.hashCode()));
+        result = ((result* 31)+((this.customData == null)? 0 :this.customData.hashCode()));
+        result = ((result* 31)+((this.customDataContentType == null)? 0 :this.customDataContentType.hashCode()));
+        result = ((result* 31)+((this.subject == null)? 0 :this.subject.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Testsuiterunstarted) == false) {
+            return false;
+        }
+        Testsuiterunstarted rhs = ((Testsuiterunstarted) other);
+        return (((((this.context == rhs.context)||((this.context!= null)&&this.context.equals(rhs.context)))&&((this.customData == rhs.customData)||((this.customData!= null)&&this.customData.equals(rhs.customData))))&&((this.customDataContentType == rhs.customDataContentType)||((this.customDataContentType!= null)&&this.customDataContentType.equals(rhs.customDataContentType))))&&((this.subject == rhs.subject)||((this.subject!= null)&&this.subject.equals(rhs.subject))));
+    }
+
 }

--- a/sdk/src/main/java/dev/cdevents/models/testsuiterun/started/Trigger.java
+++ b/sdk/src/main/java/dev/cdevents/models/testsuiterun/started/Trigger.java
@@ -60,6 +60,27 @@ public class Trigger {
         this.additionalProperties.put(name, value);
     }
 
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
+        result = ((result* 31)+((this.type == null)? 0 :this.type.hashCode()));
+        result = ((result* 31)+((this.uri == null)? 0 :this.uri.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Trigger) == false) {
+            return false;
+        }
+        Trigger rhs = ((Trigger) other);
+        return ((((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties)))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.uri == rhs.uri)||((this.uri!= null)&&this.uri.equals(rhs.uri))));
+    }
+
     @Generated("jsonschema2pojo")
     public enum Type {
 

--- a/sdk/src/test/java/dev/cdevents/CDEventsSpecExamplesTest.java
+++ b/sdk/src/test/java/dev/cdevents/CDEventsSpecExamplesTest.java
@@ -1,0 +1,1026 @@
+package dev.cdevents;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.cdevents.constants.CDEventConstants;
+import dev.cdevents.events.*;
+import dev.cdevents.models.CDEvent;
+import dev.cdevents.models.testcaserun.finished.Content;
+import dev.cdevents.models.testcaserun.finished.TestCase;
+import dev.cdevents.models.testcaserun.queued.Trigger;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CDEventsSpecExamplesTest {
+
+    private static String EXAMPLES_FOLDER = CDEventConstants.SPEC_REPO + File.separator + "examples";
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+
+    @Test
+    void testArtifactPackagedCDEvent() throws IOException {
+
+        File artifactPackagedExample = new File(EXAMPLES_FOLDER + File.separator + "artifact_packaged.json");
+        JsonNode expectedNode = objectMapper.readTree(artifactPackagedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        ArtifactPackagedCDEvent expectedEvent = (ArtifactPackagedCDEvent) expectedCDEvent;
+
+        ArtifactPackagedCDEvent createdEvent =  new ArtifactPackagedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectChangeId("myChange123");
+        createdEvent.setSubjectChangeSource("my-git.example/an-org/a-repo");
+
+        //replace context id, timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+    @Test
+    void testArtifactPublishedCDEvent() throws IOException {
+
+        File artifactPublishedExample = new File(EXAMPLES_FOLDER + File.separator + "artifact_published.json");
+        JsonNode expectedNode = objectMapper.readTree(artifactPublishedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        ArtifactPublishedCDEvent expectedEvent = (ArtifactPublishedCDEvent) expectedCDEvent;
+
+        ArtifactPublishedCDEvent createdEvent =  new ArtifactPublishedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+
+        //replace context id, timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testArtifactSignedCDEvent() throws IOException {
+
+        File artifactSignedExample = new File(EXAMPLES_FOLDER + File.separator + "artifact_signed.json");
+        JsonNode expectedNode = objectMapper.readTree(artifactSignedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        ArtifactSignedCDEvent expectedEvent = (ArtifactSignedCDEvent) expectedCDEvent;
+
+        ArtifactSignedCDEvent createdEvent =  new ArtifactSignedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectSignature("MEYCIQCBT8U5ypDXWCjlNKfzTV4KH516/SK13NZSh8znnSMNkQIhAJ3XiQlc9PM1KyjITcZXHotdMB+J3NGua5T/yshmiPmp");
+
+        //replace context id, timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testBranchCreatedCDEvent() throws IOException {
+
+        File branchCreatedExample = new File(EXAMPLES_FOLDER + File.separator + "branch_created.json");
+        JsonNode expectedNode = objectMapper.readTree(branchCreatedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        BranchCreatedCDEvent expectedEvent = (BranchCreatedCDEvent) expectedCDEvent;
+
+        BranchCreatedCDEvent createdEvent =  new BranchCreatedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectRepositoryId("TestRepo/TestOrg");
+        createdEvent.setSubjectRepositorySource("https://example.org");
+
+        //replace context id, timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testBranchDeletedCDEvent() throws IOException {
+
+        File branchDeletedExample = new File(EXAMPLES_FOLDER + File.separator + "branch_deleted.json");
+        JsonNode expectedNode = objectMapper.readTree(branchDeletedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        BranchDeletedCDEvent expectedEvent = (BranchDeletedCDEvent) expectedCDEvent;
+
+        BranchDeletedCDEvent createdEvent =  new BranchDeletedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectRepositoryId("TestRepo/TestOrg");
+        createdEvent.setSubjectRepositorySource("https://example.org");
+
+        //replace context id, timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+    @Test
+    void testBuildFinishedCDEvent() throws IOException {
+
+        File buildFinishedExample = new File(EXAMPLES_FOLDER + File.separator + "build_finished.json");
+        JsonNode expectedNode = objectMapper.readTree(buildFinishedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        BuildFinishedCDEvent expectedEvent = (BuildFinishedCDEvent) expectedCDEvent;
+
+        BuildFinishedCDEvent createdEvent =  new BuildFinishedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectArtifactId("pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427");
+
+        //replace context id, timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testBuildQueuedCDEvent() throws IOException {
+
+        File buildQueuedExample = new File(EXAMPLES_FOLDER + File.separator + "build_queued.json");
+        JsonNode expectedNode = objectMapper.readTree(buildQueuedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        BuildQueuedCDEvent expectedEvent = (BuildQueuedCDEvent) expectedCDEvent;
+
+        BuildQueuedCDEvent createdEvent =  new BuildQueuedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+
+        //replace context id, timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testBuildStartedCDEvent() throws IOException {
+
+        File buildStartedExample = new File(EXAMPLES_FOLDER + File.separator + "build_started.json");
+        JsonNode expectedNode = objectMapper.readTree(buildStartedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        BuildStartedCDEvent expectedEvent = (BuildStartedCDEvent) expectedCDEvent;
+
+        BuildStartedCDEvent createdEvent =  new BuildStartedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testChangeAbandonedCDEvent() throws IOException {
+
+        File changeAbandonedExample = new File(EXAMPLES_FOLDER + File.separator + "change_abandoned.json");
+        JsonNode expectedNode = objectMapper.readTree(changeAbandonedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        ChangeAbandonedCDEvent expectedEvent = (ChangeAbandonedCDEvent) expectedCDEvent;
+
+        ChangeAbandonedCDEvent createdEvent =  new ChangeAbandonedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectRepositoryId("TestRepo/TestOrg");
+        createdEvent.setSubjectRepositorySource("https://example.org");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testChangeCreatedCDEvent() throws IOException {
+
+        File changeCreatedExample = new File(EXAMPLES_FOLDER + File.separator + "change_created.json");
+        JsonNode expectedNode = objectMapper.readTree(changeCreatedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        ChangeCreatedCDEvent expectedEvent = (ChangeCreatedCDEvent) expectedCDEvent;
+
+        ChangeCreatedCDEvent createdEvent =  new ChangeCreatedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectRepositoryId("TestRepo/TestOrg");
+        createdEvent.setSubjectRepositorySource("https://example.org");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testChangeMergedCDEvent() throws IOException {
+
+        File changeMergedExample = new File(EXAMPLES_FOLDER + File.separator + "change_merged.json");
+        JsonNode expectedNode = objectMapper.readTree(changeMergedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        ChangeMergedCDEvent expectedEvent = (ChangeMergedCDEvent) expectedCDEvent;
+
+        ChangeMergedCDEvent createdEvent =  new ChangeMergedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectRepositoryId("TestRepo/TestOrg");
+        createdEvent.setSubjectRepositorySource("https://example.org");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testChangeReviewedCDEvent() throws IOException {
+
+        File changeReviewedExample = new File(EXAMPLES_FOLDER + File.separator + "change_reviewed.json");
+        JsonNode expectedNode = objectMapper.readTree(changeReviewedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        ChangeReviewedCDEvent expectedEvent = (ChangeReviewedCDEvent) expectedCDEvent;
+
+        ChangeReviewedCDEvent createdEvent =  new ChangeReviewedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectRepositoryId("TestRepo/TestOrg");
+        createdEvent.setSubjectRepositorySource("https://example.org");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testChangeUpdatedCDEvent() throws IOException {
+
+        File changeUpdatedExample = new File(EXAMPLES_FOLDER + File.separator + "change_updated.json");
+        JsonNode expectedNode = objectMapper.readTree(changeUpdatedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        ChangeUpdatedCDEvent expectedEvent = (ChangeUpdatedCDEvent) expectedCDEvent;
+
+        ChangeUpdatedCDEvent createdEvent =  new ChangeUpdatedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectRepositoryId("TestRepo/TestOrg");
+        createdEvent.setSubjectRepositorySource("https://example.org");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testEnvironmentCreatedCDEvent() throws IOException {
+
+        File environmentCreatedExample = new File(EXAMPLES_FOLDER + File.separator + "environment_created.json");
+        JsonNode expectedNode = objectMapper.readTree(environmentCreatedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        EnvironmentCreatedCDEvent expectedEvent = (EnvironmentCreatedCDEvent) expectedCDEvent;
+
+        EnvironmentCreatedCDEvent createdEvent =  new EnvironmentCreatedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectName("testEnv");
+        createdEvent.setSubjectUrl("https://example.org/testEnv");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testEnvironmentDeletedCDEvent() throws IOException {
+
+        File environmentDeletedExample = new File(EXAMPLES_FOLDER + File.separator + "environment_deleted.json");
+        JsonNode expectedNode = objectMapper.readTree(environmentDeletedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        EnvironmentDeletedCDEvent expectedEvent = (EnvironmentDeletedCDEvent) expectedCDEvent;
+
+        EnvironmentDeletedCDEvent createdEvent =  new EnvironmentDeletedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectName("testEnv");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testEnvironmentModifiedCDEvent() throws IOException {
+
+        File environmentModifiedExample = new File(EXAMPLES_FOLDER + File.separator + "environment_modified.json");
+        JsonNode expectedNode = objectMapper.readTree(environmentModifiedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        EnvironmentModifiedCDEvent expectedEvent = (EnvironmentModifiedCDEvent) expectedCDEvent;
+
+        EnvironmentModifiedCDEvent createdEvent =  new EnvironmentModifiedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectName("testEnv");
+        createdEvent.setSubjectUrl("https://example.org/testEnv");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testIncidentDetectedCDEvent() throws IOException {
+
+        File incidentDetectedExample = new File(EXAMPLES_FOLDER + File.separator + "incident_detected.json");
+        JsonNode expectedNode = objectMapper.readTree(incidentDetectedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        IncidentDetectedCDEvent expectedEvent = (IncidentDetectedCDEvent) expectedCDEvent;
+
+        IncidentDetectedCDEvent createdEvent =  new IncidentDetectedCDEvent();
+        createdEvent.setSource(URI.create("/monitoring/prod1"));
+        createdEvent.setSubjectId("incident-123");
+        createdEvent.setSubjectSource(URI.create("/monitoring/prod1"));
+        createdEvent.setSubjectDescription("Response time above threshold of 100ms");
+        createdEvent.setSubjectEnvironmentId("prod1");
+        createdEvent.setSubjectEnvironmentSource("/iaas/geo1");
+        createdEvent.setSubjectServiceId("myApp");
+        createdEvent.setSubjectServiceSource("/clusterA/namespaceB");
+        createdEvent.setSubjectArtifactId("pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427");
+        Map<String,String> customMap = new HashMap<>();
+        customMap.put("metric", "responseTime");
+        customMap.put("threshold", "100ms");
+        customMap.put("value", "200ms");
+        createdEvent.setCustomData(customMap);
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+        assertEquals(expectedEvent.getCustomData(), createdEvent.getCustomData());
+        assertEquals(expectedEvent.getCustomDataContentType(), createdEvent.getCustomDataContentType());
+    }
+
+    @Test
+    void testIncidentReportedCDEvent() throws IOException {
+
+        File incidentReportedExample = new File(EXAMPLES_FOLDER + File.separator + "incident_reported.json");
+        JsonNode expectedNode = objectMapper.readTree(incidentReportedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        IncidentReportedCDEvent expectedEvent = (IncidentReportedCDEvent) expectedCDEvent;
+
+        IncidentReportedCDEvent createdEvent =  new IncidentReportedCDEvent();
+        createdEvent.setSource(URI.create("/monitoring/prod1"));
+        createdEvent.setSubjectId("incident-123");
+        createdEvent.setSubjectSource(URI.create("/monitoring/prod1"));
+        createdEvent.setSubjectDescription("Response time above threshold of 100ms");
+        createdEvent.setSubjectEnvironmentId("prod1");
+        createdEvent.setSubjectEnvironmentSource("/iaas/geo1");
+        createdEvent.setSubjectServiceId("myApp");
+        createdEvent.setSubjectServiceSource("/clusterA/namespaceB");
+        createdEvent.setSubjectArtifactId("pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427");
+        createdEvent.setSubjectTicketURI(URI.create("https://my-issues.example/incidents/ticket-345"));
+        Map<String,String> customMap = new HashMap<>();
+        customMap.put("severity", "medium");
+        customMap.put("priority", "critical");
+        customMap.put("reportedBy", "userId");
+        createdEvent.setCustomData(customMap);
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+        assertEquals(expectedEvent.getCustomData(), createdEvent.getCustomData());
+        assertEquals(expectedEvent.getCustomDataContentType(), createdEvent.getCustomDataContentType());
+    }
+
+    @Test
+    void testIncidentResolvedCDEvent() throws IOException {
+
+        File incidentResolvedExample = new File(EXAMPLES_FOLDER + File.separator + "incident_resolved.json");
+        JsonNode expectedNode = objectMapper.readTree(incidentResolvedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        IncidentResolvedCDEvent expectedEvent = (IncidentResolvedCDEvent) expectedCDEvent;
+
+        IncidentResolvedCDEvent createdEvent =  new IncidentResolvedCDEvent();
+        createdEvent.setSource(URI.create("/monitoring/prod1"));
+        createdEvent.setSubjectId("incident-123");
+        createdEvent.setSubjectSource(URI.create("/monitoring/prod1"));
+        createdEvent.setSubjectDescription("Response time restored below 100ms");
+        createdEvent.setSubjectEnvironmentId("prod1");
+        createdEvent.setSubjectEnvironmentSource("/iaas/geo1");
+        createdEvent.setSubjectServiceId("myApp");
+        createdEvent.setSubjectServiceSource("/clusterA/namespaceB");
+        createdEvent.setSubjectArtifactId("pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93439");
+        Map<String,String> customMap = new HashMap<>();
+        customMap.put("metric", "responseTime");
+        customMap.put("threshold", "100ms");
+        customMap.put("value", "70ms");
+        createdEvent.setCustomData(customMap);
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+        assertEquals(expectedEvent.getCustomData(), createdEvent.getCustomData());
+        assertEquals(expectedEvent.getCustomDataContentType(), createdEvent.getCustomDataContentType());
+    }
+
+    @Test
+    void testPipelinerunFinishedCDEvent() throws IOException {
+
+        File pipelinerunFinishedExample = new File(EXAMPLES_FOLDER + File.separator + "pipelinerun_finished.json");
+        JsonNode expectedNode = objectMapper.readTree(pipelinerunFinishedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        PipelinerunFinishedCDEvent expectedEvent = (PipelinerunFinishedCDEvent) expectedCDEvent;
+
+        PipelinerunFinishedCDEvent createdEvent =  new PipelinerunFinishedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectPipelineName("myPipeline");
+        createdEvent.setSubjectUrl("https://www.example.com/mySubject123");
+        createdEvent.setSubjectOutcome("failure");
+        createdEvent.setSubjectErrors("Something went wrong\nWith some more details");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testPipelinerunQueuedCDEvent() throws IOException {
+
+        File pipelinerunQueuedExample = new File(EXAMPLES_FOLDER + File.separator + "pipelinerun_queued.json");
+        JsonNode expectedNode = objectMapper.readTree(pipelinerunQueuedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        PipelinerunQueuedCDEvent expectedEvent = (PipelinerunQueuedCDEvent) expectedCDEvent;
+
+        PipelinerunQueuedCDEvent createdEvent =  new PipelinerunQueuedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectPipelineName("myPipeline");
+        createdEvent.setSubjectUrl("https://www.example.com/mySubject123");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+    @Test
+    void testPipelinerunStartedCDEvent() throws IOException {
+
+        File pipelinerunStartedExample = new File(EXAMPLES_FOLDER + File.separator + "pipelinerun_started.json");
+        JsonNode expectedNode = objectMapper.readTree(pipelinerunStartedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        PipelinerunStartedCDEvent expectedEvent = (PipelinerunStartedCDEvent) expectedCDEvent;
+
+        PipelinerunStartedCDEvent createdEvent =  new PipelinerunStartedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectPipelineName("myPipeline");
+        createdEvent.setSubjectUrl("https://www.example.com/mySubject123");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testRepositoryCreatedCDEvent() throws IOException {
+
+        File repositoryCreatedExample = new File(EXAMPLES_FOLDER + File.separator + "repository_created.json");
+        JsonNode expectedNode = objectMapper.readTree(repositoryCreatedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        RepositoryCreatedCDEvent expectedEvent = (RepositoryCreatedCDEvent) expectedCDEvent;
+
+        RepositoryCreatedCDEvent createdEvent =  new RepositoryCreatedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectName("TestRepo");
+        createdEvent.setSubjectOwner("TestOrg");
+        createdEvent.setSubjectUrl("https://example.org/TestOrg/TestRepo");
+        createdEvent.setSubjectViewUrl("https://example.org/view/TestOrg/TestRepo");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testRepositoryDeletedCDEvent() throws IOException {
+
+        File repositoryDeletedExample = new File(EXAMPLES_FOLDER + File.separator + "repository_deleted.json");
+        JsonNode expectedNode = objectMapper.readTree(repositoryDeletedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        RepositoryDeletedCDEvent expectedEvent = (RepositoryDeletedCDEvent) expectedCDEvent;
+
+        RepositoryDeletedCDEvent createdEvent =  new RepositoryDeletedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectName("TestRepo");
+        createdEvent.setSubjectOwner("TestOrg");
+        createdEvent.setSubjectUrl("https://example.org/TestOrg/TestRepo");
+        createdEvent.setSubjectViewUrl("https://example.org/view/TestOrg/TestRepo");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+    @Test
+    void testRepositoryModifiedCDEvent() throws IOException {
+
+        File repositoryModifiedExample = new File(EXAMPLES_FOLDER + File.separator + "repository_modified.json");
+        JsonNode expectedNode = objectMapper.readTree(repositoryModifiedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        RepositoryModifiedCDEvent expectedEvent = (RepositoryModifiedCDEvent) expectedCDEvent;
+
+        RepositoryModifiedCDEvent createdEvent =  new RepositoryModifiedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectName("TestRepo");
+        createdEvent.setSubjectOwner("TestOrg");
+        createdEvent.setSubjectUrl("https://example.org/TestOrg/TestRepo");
+        createdEvent.setSubjectViewUrl("https://example.org/view/TestOrg/TestRepo");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testServiceDeployedCDEvent() throws IOException {
+
+        File serviceDeployedExample = new File(EXAMPLES_FOLDER + File.separator + "service_deployed.json");
+        JsonNode expectedNode = objectMapper.readTree(serviceDeployedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        ServiceDeployedCDEvent expectedEvent = (ServiceDeployedCDEvent) expectedCDEvent;
+
+        ServiceDeployedCDEvent createdEvent =  new ServiceDeployedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectEnvironmentId("test123");
+        createdEvent.setSubjectArtifactId("pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+    @Test
+    void testServicePublishedCDEvent() throws IOException {
+
+        File servicePublishedExample = new File(EXAMPLES_FOLDER + File.separator + "service_published.json");
+        JsonNode expectedNode = objectMapper.readTree(servicePublishedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        ServicePublishedCDEvent expectedEvent = (ServicePublishedCDEvent) expectedCDEvent;
+
+        ServicePublishedCDEvent createdEvent =  new ServicePublishedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectEnvironmentId("test123");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testServiceRemovedCDEvent() throws IOException {
+
+        File serviceRemovedExample = new File(EXAMPLES_FOLDER + File.separator + "service_removed.json");
+        JsonNode expectedNode = objectMapper.readTree(serviceRemovedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        ServiceRemovedCDEvent expectedEvent = (ServiceRemovedCDEvent) expectedCDEvent;
+
+        ServiceRemovedCDEvent createdEvent =  new ServiceRemovedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectEnvironmentId("test123");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testServiceRolledbackCDEvent() throws IOException {
+
+        File serviceRolledbackExample = new File(EXAMPLES_FOLDER + File.separator + "service_rolledback.json");
+        JsonNode expectedNode = objectMapper.readTree(serviceRolledbackExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        ServiceRolledbackCDEvent expectedEvent = (ServiceRolledbackCDEvent) expectedCDEvent;
+
+        ServiceRolledbackCDEvent createdEvent =  new ServiceRolledbackCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectEnvironmentId("test123");
+        createdEvent.setSubjectArtifactId("pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testServiceUpgradedCDEvent() throws IOException {
+
+        File serviceUpgradedExample = new File(EXAMPLES_FOLDER + File.separator + "service_upgraded.json");
+        JsonNode expectedNode = objectMapper.readTree(serviceUpgradedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        ServiceUpgradedCDEvent expectedEvent = (ServiceUpgradedCDEvent) expectedCDEvent;
+
+        ServiceUpgradedCDEvent createdEvent =  new ServiceUpgradedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectEnvironmentId("test123");
+        createdEvent.setSubjectArtifactId("pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testTaskrunFinishedCDEvent() throws IOException {
+
+        File taskrunFinishedExample = new File(EXAMPLES_FOLDER + File.separator + "taskrun_finished.json");
+        JsonNode expectedNode = objectMapper.readTree(taskrunFinishedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        TaskrunFinishedCDEvent expectedEvent = (TaskrunFinishedCDEvent) expectedCDEvent;
+
+        TaskrunFinishedCDEvent createdEvent =  new TaskrunFinishedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectTaskName("myTask");
+        createdEvent.setSubjectUrl("https://www.example.com/mySubject123");
+        createdEvent.setSubjectPipelineRunId("mySubject123");
+        createdEvent.setSubjectOutcome("failure");
+        createdEvent.setSubjectErrors("Something went wrong\nWith some more details");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testTaskrunStartedCDEvent() throws IOException {
+
+        File taskrunStartedExample = new File(EXAMPLES_FOLDER + File.separator + "taskrun_started.json");
+        JsonNode expectedNode = objectMapper.readTree(taskrunStartedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        TaskrunStartedCDEvent expectedEvent = (TaskrunStartedCDEvent) expectedCDEvent;
+
+        TaskrunStartedCDEvent createdEvent =  new TaskrunStartedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("mySubject123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectTaskName("myTask");
+        createdEvent.setSubjectUrl("https://www.example.com/mySubject123");
+        createdEvent.setSubjectPipelineRunId("mySubject123");
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testTestcaserunFinishedCDEvent() throws IOException {
+
+        File testcaserunFinishedExample = new File(EXAMPLES_FOLDER + File.separator + "testcaserun_finished.json");
+        JsonNode expectedNode = objectMapper.readTree(testcaserunFinishedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        TestcaserunFinishedCDEvent expectedEvent = (TestcaserunFinishedCDEvent) expectedCDEvent;
+
+        TestcaserunFinishedCDEvent createdEvent =  new TestcaserunFinishedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("myTestCaseRun123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectOutcome(Content.Outcome.PASS);
+        createdEvent.setSubjectEnvironmentId("dev");
+        createdEvent.setSubjectEnvironmentSource("testkube-dev-123");
+        createdEvent.setSubjectTestCaseId("92834723894");
+        createdEvent.setSubjectTestCaseVersion("1.0");
+        createdEvent.setSubjectTestCaseName("Login Test");
+        createdEvent.setSubjectTestCaseType(TestCase.Type.INTEGRATION);
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject().getContent().getOutcome(), createdEvent.getSubject().getContent().getOutcome());
+        assertEquals(expectedEvent.getSubject().getContent().getTestCase(), createdEvent.getSubject().getContent().getTestCase());
+        assertEquals(expectedEvent.getSubject().getContent().getEnvironment(), createdEvent.getSubject().getContent().getEnvironment());
+    }
+
+    @Test
+    void testTestcaserunQueuedCDEvent() throws IOException {
+
+        File testcaserunQueuedExample = new File(EXAMPLES_FOLDER + File.separator + "testcaserun_queued.json");
+        JsonNode expectedNode = objectMapper.readTree(testcaserunQueuedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        TestcaserunQueuedCDEvent expectedEvent = (TestcaserunQueuedCDEvent) expectedCDEvent;
+
+        TestcaserunQueuedCDEvent createdEvent =  new TestcaserunQueuedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("myTestCaseRun123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectEnvironmentId("dev");
+        createdEvent.setSubjectEnvironmentSource("testkube-dev-123");
+        createdEvent.setSubjectTestCaseId("92834723894");
+        createdEvent.setSubjectTestCaseVersion("1.0");
+        createdEvent.setSubjectTestCaseName("Login Test");
+        createdEvent.setSubjectTestCaseType(dev.cdevents.models.testcaserun.queued.TestCase.Type.INTEGRATION);
+        createdEvent.setSubjectTriggerType(Trigger.Type.SCHEDULE);
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject().getContent().getTrigger(), createdEvent.getSubject().getContent().getTrigger());
+        assertEquals(expectedEvent.getSubject().getContent().getTestCase(), createdEvent.getSubject().getContent().getTestCase());
+        assertEquals(expectedEvent.getSubject().getContent().getEnvironment(), createdEvent.getSubject().getContent().getEnvironment());
+    }
+
+    @Test
+    void testTestcaserunStartedCDEvent() throws IOException {
+
+        File testcaserunStartedExample = new File(EXAMPLES_FOLDER + File.separator + "testcaserun_started.json");
+        JsonNode expectedNode = objectMapper.readTree(testcaserunStartedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        TestcaserunStartedCDEvent expectedEvent = (TestcaserunStartedCDEvent) expectedCDEvent;
+
+        TestcaserunStartedCDEvent createdEvent =  new TestcaserunStartedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("myTestCaseRun123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectEnvironmentId("dev");
+        createdEvent.setSubjectEnvironmentSource("testkube-dev-123");
+        createdEvent.setSubjectTestCaseId("92834723894");
+        createdEvent.setSubjectTestCaseVersion("1.0");
+        createdEvent.setSubjectTestCaseName("Login Test");
+        createdEvent.setSubjectTestCaseType(dev.cdevents.models.testcaserun.started.TestCase.Type.INTEGRATION);
+        createdEvent.setSubjectTriggerType(dev.cdevents.models.testcaserun.started.Trigger.Type.SCHEDULE);
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject().getContent().getTrigger(), createdEvent.getSubject().getContent().getTrigger());
+        assertEquals(expectedEvent.getSubject().getContent().getTestCase(), createdEvent.getSubject().getContent().getTestCase());
+        assertEquals(expectedEvent.getSubject().getContent().getEnvironment(), createdEvent.getSubject().getContent().getEnvironment());
+    }
+
+    @Test
+    void testTestoutputPublishedCDEvent() throws IOException {
+
+        File testoutputPublishedExample = new File(EXAMPLES_FOLDER + File.separator + "testoutput_published.json");
+        JsonNode expectedNode = objectMapper.readTree(testoutputPublishedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        TestoutputPublishedCDEvent expectedEvent = (TestoutputPublishedCDEvent) expectedCDEvent;
+
+        TestoutputPublishedCDEvent createdEvent =  new TestoutputPublishedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("testrunreport-12123");
+        createdEvent.setSubjectSource(URI.create("/event/source/testrunreport-12123"));
+        createdEvent.setSubjectOutputType(dev.cdevents.models.testoutput.published.Content.OutputType.VIDEO);
+        createdEvent.setSubjectFormat("video/quicktime");
+        createdEvent.setSubjectTestCaseRunId("myTestCaseRun123");
+        createdEvent.setSubjectTestCaseRunSource("testkube-dev-123");
+
+
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testTestsuiterunFinishedCDEvent() throws IOException {
+
+        File testsuiterunFinishedExample = new File(EXAMPLES_FOLDER + File.separator + "testsuiterun_finished.json");
+        JsonNode expectedNode = objectMapper.readTree(testsuiterunFinishedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        TestsuiterunFinishedCDEvent expectedEvent = (TestsuiterunFinishedCDEvent) expectedCDEvent;
+
+        TestsuiterunFinishedCDEvent createdEvent =  new TestsuiterunFinishedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("myTestSuiteRun123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectOutcome(dev.cdevents.models.testsuiterun.finished.Content.Outcome.FAIL);
+        createdEvent.setSubjectSeverity(dev.cdevents.models.testsuiterun.finished.Content.Severity.CRITICAL);
+        createdEvent.setSubjectReason("Host 123.34.23.32 not found");
+        createdEvent.setSubjectEnvironmentId("dev");
+        createdEvent.setSubjectEnvironmentSource("testkube-dev-123");
+        createdEvent.setSubjectTestSuiteId("92834723894");
+        createdEvent.setSubjectTestSuiteVersion("1.0");
+        createdEvent.setSubjectTestSuiteName("Auth TestSuite");
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testTestsuiterunQueuedCDEvent() throws IOException {
+
+        File testsuiterunQueuedExample = new File(EXAMPLES_FOLDER + File.separator + "testsuiterun_queued.json");
+        JsonNode expectedNode = objectMapper.readTree(testsuiterunQueuedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        TestsuiterunQueuedCDEvent expectedEvent = (TestsuiterunQueuedCDEvent) expectedCDEvent;
+
+        TestsuiterunQueuedCDEvent createdEvent =  new TestsuiterunQueuedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("myTestSuiteRun123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectEnvironmentId("dev");
+        createdEvent.setSubjectEnvironmentSource("testkube-dev-123");
+        createdEvent.setSubjectTestSuiteId("92834723894");
+        createdEvent.setSubjectTestSuiteVersion("1.0");
+        createdEvent.setSubjectTestSuiteName("Auth TestSuite");
+        createdEvent.setSubjectTriggerType(dev.cdevents.models.testsuiterun.queued.Trigger.Type.PIPELINE);
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+
+    @Test
+    void testTestsuiterunStartedCDEvent() throws IOException {
+
+        File testsuiterunStartedExample = new File(EXAMPLES_FOLDER + File.separator + "testsuiterun_started.json");
+        JsonNode expectedNode = objectMapper.readTree(testsuiterunStartedExample);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+        CDEvent expectedCDEvent = CDEvents.cdEventFromJson(expectedJson);
+        TestsuiterunStartedCDEvent expectedEvent = (TestsuiterunStartedCDEvent) expectedCDEvent;
+
+        TestsuiterunStartedCDEvent createdEvent =  new TestsuiterunStartedCDEvent();
+        createdEvent.setSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectId("myTestSuiteRun123");
+        createdEvent.setSubjectSource(URI.create("/event/source/123"));
+        createdEvent.setSubjectEnvironmentId("dev");
+        createdEvent.setSubjectEnvironmentSource("testkube-dev-123");
+        createdEvent.setSubjectTestSuiteId("92834723894");
+        createdEvent.setSubjectTestSuiteVersion("1.0");
+        createdEvent.setSubjectTestSuiteName("Auth TestSuite");
+        createdEvent.setSubjectTriggerType(dev.cdevents.models.testsuiterun.started.Trigger.Type.PIPELINE);
+        //replace createdEvent's context id and timestamp from the expectedEvent to compare objects directly
+        createdEvent.getContext().setId(expectedEvent.getContext().getId());
+        createdEvent.getContext().setTimestamp(expectedEvent.getContext().getTimestamp());
+
+        assertEquals(expectedEvent.getContext(), createdEvent.getContext());
+        assertEquals(expectedEvent.getSubject(), createdEvent.getSubject());
+    }
+}

--- a/sdk/src/test/java/dev/cdevents/CDEventsTest.java
+++ b/sdk/src/test/java/dev/cdevents/CDEventsTest.java
@@ -8,7 +8,6 @@ import dev.cdevents.config.CustomObjectMapper;
 import dev.cdevents.constants.CDEventConstants;
 import dev.cdevents.events.*;
 import dev.cdevents.exception.CDEventsException;
-import dev.cdevents.models.incident.detected.Incidentdetected;
 import dev.cdevents.models.testcaserun.finished.Content;
 import io.cloudevents.CloudEvent;
 import org.junit.jupiter.api.Test;
@@ -1603,6 +1602,47 @@ public class CDEventsTest {
             CDEvents.cdEventAsCloudEvent(cdEvent);
         });
         String expectedError = "CDEvent validation failed against schema URL - " + cdEvent.schemaURL();
+
+        assertThat(exception.getMessage()).isEqualTo(expectedError);
+    }
+
+    @Test
+    void testInvalidArtifactPackagedEventJson() throws IOException {
+        InputStream inputStream = getClass().getResourceAsStream("/artifact_packaged_with_no_content.json");
+        JsonNode expectedNode = objectMapper.readTree(inputStream);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+
+        Exception exception = assertThrows(CDEventsException.class, () -> {
+            CDEvents.cdEventFromJson(expectedJson);
+        });
+        String expectedError = "CDEvent Json validation failed against schema";
+
+        assertThat(exception.getMessage()).isEqualTo(expectedError);
+    }
+
+    @Test
+    void testInvalidArtifactPublishedEventJson() throws IOException {
+        InputStream inputStream = getClass().getResourceAsStream("/artifact_published_with_no_context.json");
+        JsonNode expectedNode = objectMapper.readTree(inputStream);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+
+        Exception exception = assertThrows(CDEventsException.class, () -> {
+            CDEvents.cdEventFromJson(expectedJson);
+        });
+        String expectedError = "Unable to find context and type in CDEvent Json";
+
+        assertThat(exception.getMessage()).isEqualTo(expectedError);
+    }
+    @Test
+    void testInvalidArtifactSignedEventJson() throws IOException {
+        InputStream inputStream = getClass().getResourceAsStream("/artifact_signed_with_invalid_type.json");
+        JsonNode expectedNode = objectMapper.readTree(inputStream);
+        String expectedJson = objectMapper.writeValueAsString(expectedNode);
+
+        Exception exception = assertThrows(CDEventsException.class, () -> {
+            CDEvents.cdEventFromJson(expectedJson);
+        });
+        String expectedError = "Invalid CDEvent type found from cdEventJson";
 
         assertThat(exception.getMessage()).isEqualTo(expectedError);
     }

--- a/sdk/src/test/resources/artifact_packaged_with_no_content.json
+++ b/sdk/src/test/resources/artifact_packaged_with_no_content.json
@@ -1,0 +1,14 @@
+{
+  "context": {
+    "version": "0.3.0",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "source": "/event/source/123",
+    "type": "dev.cdevents.artifact.packaged.0.1.1",
+    "timestamp": "2023-03-20T14:27:05.315384Z"
+  },
+  "subject": {
+    "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",
+    "source": "/event/source/123",
+    "type": "artifact"
+  }
+}

--- a/sdk/src/test/resources/artifact_published_with_no_context.json
+++ b/sdk/src/test/resources/artifact_published_with_no_context.json
@@ -1,0 +1,8 @@
+{
+  "subject": {
+    "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",
+    "source": "/event/source/123",
+    "type": "artifact",
+    "content": {}
+  }
+}

--- a/sdk/src/test/resources/artifact_signed_with_invalid_type.json
+++ b/sdk/src/test/resources/artifact_signed_with_invalid_type.json
@@ -1,0 +1,17 @@
+{
+  "context": {
+    "version": "0.3.0",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "source": "/event/source/123",
+    "type": "dev.cdevents.artifact.invalid.0.1.0",
+    "timestamp": "2023-03-20T14:27:05.315384Z"
+  },
+  "subject": {
+    "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",
+    "source": "/event/source/123",
+    "type": "artifact",
+    "content": {
+      "signature": "MEYCIQCBT8U5ypDXWCjlNKfzTV4KH516/SK13NZSh8znnSMNkQIhAJ3XiQlc9PM1KyjITcZXHotdMB+J3NGua5T/yshmiPmp"
+    }
+  }
+}


### PR DESCRIPTION
This PR includes the changes to,
1. Fix the issue https://github.com/cdevents/sdk-java/issues/28 to add [tests](https://github.com/Nordix/sdk-java/blob/69aa1627e3979c3f19ccc3c62d35f45a3fdd81a8/sdk/src/test/java/dev/cdevents/CDEventsSpecExamplesTest.java) to compare [examples](https://github.com/cdevents/spec/tree/v0.3.0/examples) from spec repo
2. Adding methods to create and validate a CDEvent in a Json string format and tests to validate
3. Updating events to generate hashCode() and equals() methods to validate the Objects